### PR TITLE
meta-adi-xilinx: Add support for ad9467_fmc_kc705

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
+	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
 	file://pl-delete-nodes-kcu105-fmcdaq2.dtsi"
 
 # Set this variable with the desired device tree
@@ -20,6 +21,7 @@ SRC_URI += " \
 #	* zynqmp-zcu102-rev10-adrv9009
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
+#	* kc705_ad9467_fmc
 #	* kcu105_fmcdaq2
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
@@ -28,7 +30,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9434-fmc-500ebz \
 			zynq-zc706-adv7511-fmcdaq2"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009"
-KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2"
+KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
+				kc705_ad9467_fmc"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"
@@ -101,6 +104,9 @@ do_configure_append() {
 		;;
 		"kc705_fmcdaq2")
 			set_common_vars pl-delete-nodes-kc705-fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
+		;;
+		"kc705_ad9467_fmc")
+			set_common_vars pl-delete-nodes-kc705_ad9467_fmc.dtsi "${WORKDIR}/system-user.dtsi"
 		;;
 		"kcu105_fmcdaq2")
 			set_common_vars pl-delete-nodes-kcu105-fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_ad9467_fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_ad9467_fmc.dtsi
@@ -1,0 +1,20 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9467;
+/delete-node/ &axi_ad9467_dma;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;


### PR DESCRIPTION
Support for kc705_ad9467_fmc.

Signed-off-by: Nuno Sa <Nuno.Sa@analog.com>