### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -11,7 +11,8 @@ SRC_URI += " \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
-	file://pl-delete-nodes-kcu105-fmcdaq2.dtsi"
+	file://pl-delete-nodes-kcu105-fmcdaq2.dtsi \
+	file://pl-delete-nodes-vc707_fmcdaq2.dtsi"
 
 # Set this variable with the desired device tree
 # Supported device tree files
@@ -27,6 +28,7 @@ SRC_URI += " \
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
 #	* kcu105_fmcdaq2
+#	* vc707_fmcdaq2
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
 # used for sanity check
@@ -37,7 +39,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
-				kc705_ad9467_fmc"
+				kc705_ad9467_fmc \
+				vc707_fmcdaq2"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"
@@ -123,6 +126,9 @@ do_configure_append() {
 		;;
 		"kcu105_fmcdaq2")
 			set_common_vars pl-delete-nodes-kcu105-fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
+		;;
+		"vc707_fmcdaq2")
+			set_common_vars pl-delete-nodes-vc707_fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
 		;;
 		*)
 			bbfatal "ERROR: Unhandled dtb file:${KERNEL_DTB}"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
+	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
@@ -24,6 +25,7 @@ SRC_URI += " \
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
+#	* zynqmp-zcu102-rev10-fmcdaq2
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
@@ -37,7 +39,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcdaq2 \
 			zynq-zed-adv7511-fmcmotcon2 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz"
-KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009"
+KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
+			zynqmp-zcu102-rev10-fmcdaq2"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
 				kc705_ad9467_fmc \
 				vc707_fmcdaq2"
@@ -116,6 +119,10 @@ do_configure_append() {
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")
 			set_common_vars pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
+			sed -i 's,[/#]include.*\"zynqmp.dtsi\",,;s,[/#]include.*\"zynqmp-clk-ccf.dtsi\",,' "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
+		;;
+		"zynqmp-zcu102-rev10-fmcdaq2")
+			set_common_vars pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
 			sed -i 's,[/#]include.*\"zynqmp.dtsi\",,;s,[/#]include.*\"zynqmp-clk-ccf.dtsi\",,' "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
 		;;
 		"kc705_fmcdaq2")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \
+	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
@@ -17,6 +18,7 @@ SRC_URI += " \
 #	* zynq-zed-adv7511-ad9361-fmcomms2-3
 #	* zynq-zc706-adv7511-ad9434-fmc-500ebz
 #	* zynq-zc706-adv7511-fmcdaq2
+#	* zynq-zed-adv7511-fmcmotcon2
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #  - For microblaze platforms
@@ -28,7 +30,8 @@ KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 # used for sanity check
 KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9434-fmc-500ebz \
-			zynq-zc706-adv7511-fmcdaq2"
+			zynq-zc706-adv7511-fmcdaq2 \
+			zynq-zed-adv7511-fmcmotcon2"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
 				kc705_ad9467_fmc"
@@ -96,6 +99,9 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-fmcdaq2")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		"zynq-zed-adv7511-fmcmotcon2")
+			set_common_vars pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -7,6 +7,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
@@ -23,6 +24,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-fmcdaq2
 #	* zynq-zed-adv7511-fmcmotcon2
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
+#	* zynq-zc706-adv7511-adrv9009
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -38,7 +40,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9434-fmc-500ebz \
 			zynq-zc706-adv7511-fmcdaq2 \
 			zynq-zed-adv7511-fmcmotcon2 \
-			zynq-zed-adv7511-ad9467-fmc-250ebz"
+			zynq-zed-adv7511-ad9467-fmc-250ebz \
+			zynq-zc706-adv7511-adrv9009"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
@@ -115,6 +118,9 @@ do_configure_append() {
 		;;
 		"zynq-zed-adv7511-ad9467-fmc-250ebz")
 			set_common_vars pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		"zynq-zc706-adv7511-adrv9009")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -6,6 +6,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
+	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
@@ -19,6 +20,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9434-fmc-500ebz
 #	* zynq-zc706-adv7511-fmcdaq2
 #	* zynq-zed-adv7511-fmcmotcon2
+#	* zynq-zed-adv7511-ad9467-fmc-250ebz
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #  - For microblaze platforms
@@ -31,7 +33,8 @@ KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9434-fmc-500ebz \
 			zynq-zc706-adv7511-fmcdaq2 \
-			zynq-zed-adv7511-fmcmotcon2"
+			zynq-zed-adv7511-fmcmotcon2 \
+			zynq-zed-adv7511-ad9467-fmc-250ebz"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
 				kc705_ad9467_fmc"
@@ -102,6 +105,10 @@ do_configure_append() {
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		"zynq-zed-adv7511-fmcmotcon2")
 			set_common_vars pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zed-adv7511-ad9467-fmc-250ebz")
+			set_common_vars pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcdaq2.dtsi
@@ -1,0 +1,27 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9144_core;
+/delete-node/ &axi_ad9144_dma;
+/delete-node/ &axi_ad9144_jesd_tx_axi;
+/delete-node/ &axi_ad9144_xcvr;
+/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_dma;
+/delete-node/ &axi_ad9680_jesd_rx_axi;
+/delete-node/ &axi_ad9680_xcvr;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
@@ -1,0 +1,29 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_adrv9009_rx_clkgen;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_adrv9009_rx_dma;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_adrv9009_rx_jesd_rx_axi;
+/delete-node/ &axi_adrv9009_rx_os_clkgen;
+/delete-node/ &axi_adrv9009_rx_os_dma;
+/delete-node/ &axi_adrv9009_rx_os_jesd_rx_axi;
+/delete-node/ &axi_adrv9009_rx_os_xcvr;
+/delete-node/ &axi_adrv9009_rx_xcvr;
+/delete-node/ &axi_adrv9009_tx_clkgen;
+/delete-node/ &axi_adrv9009_tx_dma;
+/delete-node/ &axi_adrv9009_tx_jesd_tx_axi;
+/delete-node/ &axi_adrv9009_tx_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_3;
+/delete-node/ &rx_adrv9009_tpl_core_tpl_core;
+/delete-node/ &rx_os_adrv9009_tpl_core_tpl_core;
+/delete-node/ &tx_adrv9009_tpl_core_tpl_core;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9467;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9467_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_iic_fmc;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi
@@ -1,0 +1,27 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_iic_fmc;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &controller_m1;
+/delete-node/ &misc_clk_2;
+/delete-node/ &controller_m2;
+/delete-node/ &current_monitor_m1;
+/delete-node/ &current_monitor_m1_dma;
+/delete-node/ &current_monitor_m2;
+/delete-node/ &current_monitor_m2_dma;
+/delete-node/ &iic_ee2;
+/delete-node/ &speed_detector_m1;
+/delete-node/ &speed_detector_m1_dma;
+/delete-node/ &speed_detector_m2;
+/delete-node/ &speed_detector_m2_dma;
+/delete-node/ &xadc_core;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi
@@ -1,0 +1,16 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9144_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9144_dma;
+/delete-node/ &axi_ad9144_jesd_tx_axi;
+/delete-node/ &axi_ad9144_xcvr;
+/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_dma;
+/delete-node/ &axi_ad9680_jesd_rx_axi;
+/delete-node/ &axi_ad9680_xcvr;
+/delete-node/ &psu_ctrl_ipi;
+/delete-node/ &psu_message_buffers;


### PR DESCRIPTION
This PR adds support for:

- zynq-zed-adv7511-ad9467-fmc-250ebz;

- zynq-zed-adv7511-fmcmotcon2;

- vc707_fmcdaq2;

- zynqmp-zcu102-rev10-fmcdaq2;

- zynq-zc706-adv7511-adrv9009.
