### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -10,6 +10,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -31,6 +32,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-adrv9009
 #	* zynq-zc706-adv7511-fmcadc4
 #	* zynq-zc706-adv7511-adrv9371
+#	* zynq-zc706-adv7511-ad6676-fmc
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -51,7 +53,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz \
 			zynq-zc706-adv7511-adrv9009 \
 			zynq-zc706-adv7511-fmcadc4 \
-			zynq-zc706-adv7511-adrv9371"
+			zynq-zc706-adv7511-adrv9371 \
+			zynq-zc706-adv7511-ad6676-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371"
@@ -144,6 +147,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-adrv9371")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-ad6676-fmc")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -8,6 +8,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
@@ -25,6 +26,7 @@ SRC_URI += " \
 #	* zynq-zed-adv7511-fmcmotcon2
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
 #	* zynq-zc706-adv7511-adrv9009
+#	* zynq-zc706-adv7511-fmcadc4
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -41,7 +43,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcdaq2 \
 			zynq-zed-adv7511-fmcmotcon2 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz \
-			zynq-zc706-adv7511-adrv9009"
+			zynq-zc706-adv7511-adrv9009 \
+			zynq-zc706-adv7511-fmcadc4"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
@@ -123,6 +126,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-adrv9009")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-fmcadc4")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -15,6 +15,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
 	file://pl-delete-nodes-kcu105-fmcdaq2.dtsi \
+	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
 	file://pl-delete-nodes-vc707_fmcdaq2.dtsi"
 
 # Set this variable with the desired device tree
@@ -34,6 +35,7 @@ SRC_URI += " \
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
 #	* kcu105_fmcdaq2
+#	* kcu105_adrv9371x
 #	* vc707_fmcdaq2
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
@@ -47,7 +49,9 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcadc4"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2"
-KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 kcu105_fmcdaq2 \
+KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
+				kcu105_adrv9371x \
+				kcu105_fmcdaq2 \
 				kc705_ad9467_fmc \
 				vc707_fmcdaq2"
 
@@ -148,6 +152,9 @@ do_configure_append() {
 		;;
 		"kcu105_fmcdaq2")
 			set_common_vars pl-delete-nodes-kcu105-fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
+		;;
+		"kcu105_adrv9371x")
+			set_common_vars pl-delete-nodes-kcu105_adrv9371x.dtsi "${WORKDIR}/system-user.dtsi"
 		;;
 		"vc707_fmcdaq2")
 			set_common_vars pl-delete-nodes-vc707_fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -9,6 +9,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
@@ -28,6 +29,7 @@ SRC_URI += " \
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
 #	* zynq-zc706-adv7511-adrv9009
 #	* zynq-zc706-adv7511-fmcadc4
+#	* zynq-zc706-adv7511-adrv9371
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -46,7 +48,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-adv7511-fmcmotcon2 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz \
 			zynq-zc706-adv7511-adrv9009 \
-			zynq-zc706-adv7511-fmcadc4"
+			zynq-zc706-adv7511-fmcadc4 \
+			zynq-zc706-adv7511-adrv9371"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
@@ -134,6 +137,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-fmcadc4")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-adrv9371")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -12,6 +12,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
+	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
@@ -33,6 +34,7 @@ SRC_URI += " \
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
+#	* zynqmp-zcu102-rev10-adrv9371
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
@@ -51,7 +53,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcadc4 \
 			zynq-zc706-adv7511-adrv9371"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
-			zynqmp-zcu102-rev10-fmcdaq2"
+			zynqmp-zcu102-rev10-fmcdaq2 \
+			zynqmp-zcu102-rev10-adrv9371"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \
@@ -149,6 +152,10 @@ do_configure_append() {
 		;;
 		"zynqmp-zcu102-rev10-fmcdaq2")
 			set_common_vars pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
+			sed -i 's,[/#]include.*\"zynqmp.dtsi\",,;s,[/#]include.*\"zynqmp-clk-ccf.dtsi\",,' "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
+		;;
+		"zynqmp-zcu102-rev10-adrv9371")
+			set_common_vars pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
 			sed -i 's,[/#]include.*\"zynqmp.dtsi\",,;s,[/#]include.*\"zynqmp-clk-ccf.dtsi\",,' "${DTS_INCLUDE_PATH}/zynqmp-zcu102-revA.dts"
 		;;
 		"kc705_fmcdaq2")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
@@ -1,0 +1,33 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9371_rx_clkgen;
+/delete-node/ &axi_ad9371_rx_dma;
+/delete-node/ &axi_ad9371_rx_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_clkgen;
+/delete-node/ &axi_ad9371_rx_os_dma;
+/delete-node/ &axi_ad9371_rx_os_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_xcvr;
+/delete-node/ &axi_ad9371_rx_xcvr;
+/delete-node/ &axi_ad9371_tx_clkgen;
+/delete-node/ &axi_ad9371_tx_dma;
+/delete-node/ &axi_ad9371_tx_jesd_tx_axi;
+/delete-node/ &axi_ad9371_tx_xcvr;
+/delete-node/ &axi_ddr_cntrl;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &rx_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
+/delete-node/ &sys_mb_debug;
+

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad6676_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad6676_dma;
+/delete-node/ &axi_ad6676_jesd_rx_axi;
+/delete-node/ &axi_ad6676_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
@@ -1,0 +1,29 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9371_rx_clkgen;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9371_rx_dma;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_ad9371_rx_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_clkgen;
+/delete-node/ &axi_ad9371_rx_os_dma;
+/delete-node/ &axi_ad9371_rx_os_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_xcvr;
+/delete-node/ &axi_ad9371_rx_xcvr;
+/delete-node/ &axi_ad9371_tx_clkgen;
+/delete-node/ &axi_ad9371_tx_dma;
+/delete-node/ &axi_ad9371_tx_jesd_tx_axi;
+/delete-node/ &axi_ad9371_tx_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_3;
+/delete-node/ &rx_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
+/delete-node/ &tx_ad9371_tpl_core_tpl_core;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi
@@ -1,0 +1,18 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9680_core_0;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9680_core_1;
+/delete-node/ &axi_ad9680_dma;
+/delete-node/ &axi_ad9680_jesd_rx_axi;
+/delete-node/ &axi_ad9680_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
@@ -1,0 +1,24 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9371_rx_clkgen;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9371_rx_dma;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_ad9371_rx_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_clkgen;
+/delete-node/ &axi_ad9371_rx_os_dma;
+/delete-node/ &axi_ad9371_rx_os_jesd_rx_axi;
+/delete-node/ &axi_ad9371_rx_os_xcvr;
+/delete-node/ &axi_ad9371_rx_xcvr;
+/delete-node/ &axi_ad9371_tx_clkgen;
+/delete-node/ &axi_ad9371_tx_dma;
+/delete-node/ &axi_ad9371_tx_jesd_tx_axi;
+/delete-node/ &axi_ad9371_tx_xcvr;
+/delete-node/ &psu_ctrl_ipi;
+/delete-node/ &psu_message_buffers;
+/delete-node/ &rx_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
+/delete-node/ &tx_ad9371_tpl_core_tpl_core;


### PR DESCRIPTION
New supported projects:

- ad6676evb_zc706;

- adrv9371x_zc706;

- adrv9371x_zcu102;

- adrv9371x_kcu105;

- fmcadc4_zc706.