### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -12,6 +12,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -35,6 +36,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-adrv9371
 #	* zynq-zc706-adv7511-ad6676-fmc
 #	* zynq-zc706-adv7511-ad9739a-fmc
+#	* zynq-zc706-adv7511-ad9625-fmcadc2
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -57,7 +59,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcadc4 \
 			zynq-zc706-adv7511-adrv9371 \
 			zynq-zc706-adv7511-ad6676-fmc \
-			zynq-zc706-adv7511-ad9739a-fmc"
+			zynq-zc706-adv7511-ad9739a-fmc \
+			zynq-zc706-adv7511-ad9625-fmcadc2"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371"
@@ -158,6 +161,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-ad9739a-fmc")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-ad9625-fmcadc2")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -14,6 +14,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
+	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -39,6 +40,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9739a-fmc
 #	* zynq-zc706-adv7511-ad9625-fmcadc2
 #	* zynq-zc706-adv7511-ad9265-fmc-125ebz
+#	* zynq-zed-imageon
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -63,7 +65,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad6676-fmc \
 			zynq-zc706-adv7511-ad9739a-fmc \
 			zynq-zc706-adv7511-ad9625-fmcadc2 \
-			zynq-zc706-adv7511-ad9265-fmc-125ebz"
+			zynq-zc706-adv7511-ad9265-fmc-125ebz \
+			zynq-zed-imageon"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371"
@@ -172,6 +175,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-ad9265-fmc-125ebz")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zed-imageon")
+			set_common_vars pl-delete-nodes-zynq-zed-imageon.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -13,6 +13,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -37,6 +38,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad6676-fmc
 #	* zynq-zc706-adv7511-ad9739a-fmc
 #	* zynq-zc706-adv7511-ad9625-fmcadc2
+#	* zynq-zc706-adv7511-ad9265-fmc-125ebz
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -60,7 +62,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-adrv9371 \
 			zynq-zc706-adv7511-ad6676-fmc \
 			zynq-zc706-adv7511-ad9739a-fmc \
-			zynq-zc706-adv7511-ad9625-fmcadc2"
+			zynq-zc706-adv7511-ad9625-fmcadc2 \
+			zynq-zc706-adv7511-ad9265-fmc-125ebz"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371"
@@ -165,6 +168,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-ad9625-fmcadc2")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-ad9265-fmc-125ebz")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -23,7 +23,8 @@ SRC_URI += " \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
 	file://pl-delete-nodes-kcu105-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
-	file://pl-delete-nodes-vc707_fmcdaq2.dtsi"
+	file://pl-delete-nodes-vc707_fmcdaq2.dtsi \
+	file://pl-delete-nodes-vc707_fmcadc2.dtsi"
 
 # Set this variable with the desired device tree
 # Supported device tree files
@@ -51,6 +52,7 @@ SRC_URI += " \
 #	* kcu105_fmcdaq2
 #	* kcu105_adrv9371x
 #	* vc707_fmcdaq2
+#	* vc707_fmcadc2
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
 # used for sanity check
@@ -74,7 +76,8 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \
 				kc705_ad9467_fmc \
-				vc707_fmcdaq2"
+				vc707_fmcdaq2 \
+				vc707_fmcadc2"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"
@@ -207,6 +210,9 @@ do_configure_append() {
 		;;
 		"vc707_fmcdaq2")
 			set_common_vars pl-delete-nodes-vc707_fmcdaq2.dtsi "${WORKDIR}/system-user.dtsi"
+		;;
+		"vc707_fmcadc2")
+			set_common_vars pl-delete-nodes-vc707_fmcadc2.dtsi "${WORKDIR}/system-user.dtsi"
 		;;
 		*)
 			bbfatal "ERROR: Unhandled dtb file:${KERNEL_DTB}"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -11,6 +11,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -33,6 +34,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-fmcadc4
 #	* zynq-zc706-adv7511-adrv9371
 #	* zynq-zc706-adv7511-ad6676-fmc
+#	* zynq-zc706-adv7511-ad9739a-fmc
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -54,7 +56,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-adrv9009 \
 			zynq-zc706-adv7511-fmcadc4 \
 			zynq-zc706-adv7511-adrv9371 \
-			zynq-zc706-adv7511-ad6676-fmc"
+			zynq-zc706-adv7511-ad6676-fmc \
+			zynq-zc706-adv7511-ad9739a-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371"
@@ -151,6 +154,10 @@ do_configure_append() {
 		;;
 		"zynq-zc706-adv7511-ad6676-fmc")
 			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi "${WORKDIR}/system-user.dtsi"
+			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
+		;;
+		"zynq-zc706-adv7511-ad9739a-fmc")
+			set_common_vars pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi "${WORKDIR}/system-user.dtsi"
 			sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"
 		;;
 		"zynqmp-zcu102-rev10-adrv9009")

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc2.dtsi
@@ -1,0 +1,23 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9625_core;
+/delete-node/ &axi_ad9625_dma;
+/delete-node/ &axi_ad9625_jesd_rx_axi;
+/delete-node/ &axi_ad9625_xcvr;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi
@@ -1,0 +1,15 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9265;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9265_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9625_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9625_dma;
+/delete-node/ &axi_ad9625_jesd_rx_axi;
+/delete-node/ &axi_ad9625_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi
@@ -1,0 +1,15 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9739a;
+/delete-node/ &axi_ad9739a_dma;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-imageon.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-imageon.dtsi
@@ -1,0 +1,19 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_hdmi_rx_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_rx_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_iic_fmc;
+/delete-node/ &axi_iic_imageon;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_rx_core;
+/delete-node/ &axi_spdif_tx_core;


### PR DESCRIPTION
New supported projects:

- ad9739a_fmc_zc706;

- fmcadc2_vc707;

- fmcadc2_zc706;

- imageon_zed;

- ad9265_fmc_zc706.