### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -18,6 +18,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
+	file://pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
@@ -49,6 +50,7 @@ SRC_URI += " \
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
 #	* zynqmp-zcu102-rev10-adrv9371
+#	* zynqmp-zcu102-rev10-ad9361-fmcomms2-3
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
@@ -77,7 +79,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-imageon"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
-			zynqmp-zcu102-rev10-adrv9371"
+			zynqmp-zcu102-rev10-adrv9371 \
+			zynqmp-zcu102-rev10-ad9361-fmcomms2-3"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -21,6 +21,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
+	file://pl-delete-nodes-kc705_fmcomms2-3.dtsi \
 	file://pl-delete-nodes-kcu105_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
 	file://pl-delete-nodes-kcu105_fmcomms2-3.dtsi \
@@ -51,6 +52,7 @@ SRC_URI += " \
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
+#	* kc705_fmcomms2-3
 #	* kcu105_fmcdaq2
 #	* kcu105_adrv9371x
 #	* kcu105_fmcomms2-3
@@ -81,6 +83,7 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_fmcdaq2 \
 				kcu105_fmcomms2-3 \
 				kc705_ad9467_fmc \
+				kc705_fmcomms2-3 \
 				vc707_fmcdaq2 \
 				vc707_fmcadc2 \
 				vc707_fmcomms2-3"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -14,6 +14,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
@@ -45,6 +46,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9739a-fmc
 #	* zynq-zc706-adv7511-ad9625-fmcadc2
 #	* zynq-zc706-adv7511-ad9265-fmc-125ebz
+#	* zynq-zc706-adv7511-ad9361-fmcomms2-3
 #	* zynq-zed-imageon
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
@@ -76,6 +78,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9739a-fmc \
 			zynq-zc706-adv7511-ad9625-fmcadc2 \
 			zynq-zc706-adv7511-ad9265-fmc-125ebz \
+			zynq-zc706-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-imageon"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -25,7 +25,8 @@ SRC_URI += " \
 	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
 	file://pl-delete-nodes-kcu105_fmcomms2-3.dtsi \
 	file://pl-delete-nodes-vc707_fmcdaq2.dtsi \
-	file://pl-delete-nodes-vc707_fmcadc2.dtsi"
+	file://pl-delete-nodes-vc707_fmcadc2.dtsi \
+	file://pl-delete-nodes-vc707_fmcomms2-3.dtsi"
 
 # Set this variable with the desired device tree
 # Supported device tree files
@@ -55,6 +56,7 @@ SRC_URI += " \
 #	* kcu105_fmcomms2-3
 #	* vc707_fmcdaq2
 #	* vc707_fmcadc2
+#	* vc707_fmcomms2-3
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
 # used for sanity check
@@ -80,7 +82,8 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_fmcomms2-3 \
 				kc705_ad9467_fmc \
 				vc707_fmcdaq2 \
-				vc707_fmcadc2"
+				vc707_fmcadc2 \
+				vc707_fmcomms2-3"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -23,6 +23,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
 	file://pl-delete-nodes-kcu105_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
+	file://pl-delete-nodes-kcu105_fmcomms2-3.dtsi \
 	file://pl-delete-nodes-vc707_fmcdaq2.dtsi \
 	file://pl-delete-nodes-vc707_fmcadc2.dtsi"
 
@@ -51,6 +52,7 @@ SRC_URI += " \
 #	* kc705_ad9467_fmc
 #	* kcu105_fmcdaq2
 #	* kcu105_adrv9371x
+#	* kcu105_fmcomms2-3
 #	* vc707_fmcdaq2
 #	* vc707_fmcadc2
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
@@ -75,6 +77,7 @@ KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \
+				kcu105_fmcomms2-3 \
 				kc705_ad9467_fmc \
 				vc707_fmcdaq2 \
 				vc707_fmcadc2"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcomms2-3.dtsi
@@ -1,0 +1,21 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9361;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcomms2-3.dtsi
@@ -1,0 +1,21 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9361;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_ddr_cntrl;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcomms2-3.dtsi
@@ -1,0 +1,22 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9361;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi
@@ -1,0 +1,16 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi
@@ -1,0 +1,11 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &psu_ctrl_ipi;
+/delete-node/ &psu_message_buffers;


### PR DESCRIPTION
New supported projects:

- fmcomms2_zc706;

- fmcomms2_vc707;

- fmcomms2_zcu102;

- fmcomms2_kcu105;

- fmcomms2_kc705.