### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -16,6 +16,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -51,6 +52,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9265-fmc-125ebz
 #	* zynq-zc706-adv7511-ad9361-fmcomms2-3
 #	* zynq-zc706-adv7511-ad9361-fmcomms5
+#	* zynq-zc706-adv7511-fmcdaq3-revC
 #	* zynq-zed-imageon
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #  - For zynqMP platforms:
@@ -86,6 +88,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9265-fmc-125ebz \
 			zynq-zc706-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9361-fmcomms5 \
+			zynq-zc706-adv7511-fmcdaq3-revC \
 			zynq-zed-imageon \
 			zynq-zc702-adv7511-ad9361-fmcomms5"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
@@ -159,7 +162,13 @@ do_configure_append() {
 
 	case ${MACHINE} in
 		"plnx-zynq7")
-			set_common_vars pl-delete-nodes-${KERNEL_DTB}.dtsi "${WORKDIR}/system-user.dtsi"
+			# zynq has some corner cases that must be taken into account
+			if [ "${KERNEL_DTB}" == "zynq-zc706-adv7511-fmcdaq3-revC" ]; then
+				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-zc706-adv7511-fmcdaq3.dts"
+			else
+				dtb_ver_file="${WORKDIR}/system-user.dtsi"
+			fi
+			set_common_vars pl-delete-nodes-${KERNEL_DTB}.dtsi "${dtb_ver_file}"
 			[ -e "${DTS_INCLUDE_PATH}/zynq.dtsi" ] && {  \
 				sed -i s,[/#]include.*\"zynq-7000.dtsi\",, "${DTS_INCLUDE_PATH}/zynq.dtsi"; }
 		;;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -17,6 +17,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
+	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -51,6 +52,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9361-fmcomms2-3
 #	* zynq-zc706-adv7511-ad9361-fmcomms5
 #	* zynq-zed-imageon
+#	* zynq-zc702-adv7511-ad9361-fmcomms5
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -84,7 +86,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9265-fmc-125ebz \
 			zynq-zc706-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9361-fmcomms5 \
-			zynq-zed-imageon"
+			zynq-zed-imageon \
+			zynq-zc702-adv7511-ad9361-fmcomms5"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -15,6 +15,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
@@ -47,6 +48,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9625-fmcadc2
 #	* zynq-zc706-adv7511-ad9265-fmc-125ebz
 #	* zynq-zc706-adv7511-ad9361-fmcomms2-3
+#	* zynq-zc706-adv7511-ad9361-fmcomms5
 #	* zynq-zed-imageon
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
@@ -79,6 +81,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9625-fmcadc2 \
 			zynq-zc706-adv7511-ad9265-fmc-125ebz \
 			zynq-zc706-adv7511-ad9361-fmcomms2-3 \
+			zynq-zc706-adv7511-ad9361-fmcomms5 \
 			zynq-zed-imageon"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -21,6 +21,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi \
+	file://pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
@@ -55,6 +56,7 @@ SRC_URI += " \
 #	* zynqmp-zcu102-rev10-fmcdaq2
 #	* zynqmp-zcu102-rev10-adrv9371
 #	* zynqmp-zcu102-rev10-ad9361-fmcomms2-3
+#	* zynqmp-zcu102-rev10-ad9361-fmcomms5
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
@@ -86,7 +88,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \
-			zynqmp-zcu102-rev10-ad9361-fmcomms2-3"
+			zynqmp-zcu102-rev10-ad9361-fmcomms2-3 \
+			zynqmp-zcu102-rev10-ad9361-fmcomms5"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -24,6 +24,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi \
+	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi \
 	file://pl-delete-nodes-fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
@@ -61,6 +62,7 @@ SRC_URI += " \
 #	* zynqmp-zcu102-rev10-adrv9371
 #	* zynqmp-zcu102-rev10-ad9361-fmcomms2-3
 #	* zynqmp-zcu102-rev10-ad9361-fmcomms5
+#	* zynqmp-zcu102-rev10-fmcdaq3
 #  - For microblaze platforms
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
@@ -95,7 +97,8 @@ KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \
 			zynqmp-zcu102-rev10-ad9361-fmcomms2-3 \
-			zynqmp-zcu102-rev10-ad9361-fmcomms5"
+			zynqmp-zcu102-rev10-ad9361-fmcomms5 \
+			zynqmp-zcu102-rev10-fmcdaq3"
 KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_adrv9371x \
 				kcu105_fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361_0;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_1;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361_0;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_1;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
@@ -1,0 +1,21 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9152_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9152_dma;
+/delete-node/ &axi_ad9152_jesd_tx_axi;
+/delete-node/ &axi_ad9152_xcvr;
+/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_dma;
+/delete-node/ &axi_ad9680_jesd_rx_axi;
+/delete-node/ &axi_ad9680_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361_0;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_1;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &psu_ctrl_ipi;
+/delete-node/ &psu_message_buffers;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
@@ -1,0 +1,17 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9152_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9152_dma;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_ad9152_jesd_tx_axi;
+/delete-node/ &axi_ad9152_xcvr;
+/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_dma;
+/delete-node/ &axi_ad9680_jesd_rx_axi;
+/delete-node/ &axi_ad9680_xcvr;
+/delete-node/ &psu_ctrl_ipi;
+/delete-node/ &psu_message_buffers;


### PR DESCRIPTION
Supported projects:

- fmcomms5_zcu10;

- fmcomms5_zc706;

- fmcomms5_zc702;

- daq3_zc706;

- daq3_zcu102.