### PR TITLE
Dev add compat series

### DIFF
--- a/meta-adi-core/conf/layer.conf
+++ b/meta-adi-core/conf/layer.conf
@@ -9,4 +9,6 @@ BBFILE_COLLECTIONS += "adi-core"
 BBFILE_PATTERN_adi-core = "^${LAYERDIR}/"
 BBFILE_PRIORITY_adi-core = "6"
 
+LAYERSERIES_COMPAT_adi-core = "rocko sumo thud warrior"
+
 LAYERDEPENDS_adi-core = "core"

--- a/meta-adi-xilinx/conf/layer.conf
+++ b/meta-adi-xilinx/conf/layer.conf
@@ -9,6 +9,9 @@ BBFILE_COLLECTIONS += "adi-xilinx"
 BBFILE_PATTERN_adi-xilinx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_adi-xilinx = "6"
 
+# the one used in petalinux 2018_R3
+LAYERSERIES_COMPAT_adi-xilinx = "rocko"
+
 LAYERDEPENDS_adi-xilinx = "core"
 LAYERDEPENDS_adi-xilinx += "xilinx"
 LAYERDEPENDS_adi-xilinx += "xilinx-tools"

--- a/meta-adi-xilinx/conf/layer.conf
+++ b/meta-adi-xilinx/conf/layer.conf
@@ -15,3 +15,6 @@ LAYERSERIES_COMPAT_adi-xilinx = "rocko"
 LAYERDEPENDS_adi-xilinx = "core"
 LAYERDEPENDS_adi-xilinx += "xilinx"
 LAYERDEPENDS_adi-xilinx += "xilinx-tools"
+LAYERDEPENDS_adi-xilinx += "petalinux"
+# for userspace tools
+LAYERDEPENDS_adi-xilinx += "adi-core"


### PR DESCRIPTION
This PR adds more important configurations to both meta-adi-core and meta-adi-xilinx. It updates the dependencies list of meta-adi-xilinx and it set's `LAYERSERIES_COMPAT` on both layers.