### PR TITLE
meta-adi-core: libiio: Add version 0.18

### DIFF
--- a/meta-adi-core/recipes-core/libiio/libiio.inc
+++ b/meta-adi-core/recipes-core/libiio/libiio.inc
@@ -1,0 +1,26 @@
+SUMMARY = "Library for interfacing with IIO devices"
+HOMEPAGE = "https://wiki.analog.com/resources/tools-software/linux-software/libiio"
+SECTION = "libs"
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
+
+BRANCH ?= "master"
+
+SRC_URI = "git://github.com/analogdevicesinc/libiio.git;branch=${BRANCH}"
+S = "${WORKDIR}/git"
+
+DEPENDS = "flex-native bison-native avahi libaio libusb1 libxml2"
+
+# skip rpath so that, do_package_qa won't complain about redundant
+# rpaths in the shared objects, since they are being installed to
+# default locations
+EXTRA_OECMAKE += "-DCMAKE_SKIP_RPATH=on -DWITH_SYSVINIT=on"
+
+inherit cmake pkgconfig update-rc.d
+
+INITSCRIPT_NAME = "iiod"
+
+# it depends on lsb to run the iiod service
+# we might want to consider in having iiod as a separate
+# package
+RDEPENDS_${PN} = "lsb"

--- a/meta-adi-core/recipes-core/libiio/libiio_0.16.bb
+++ b/meta-adi-core/recipes-core/libiio/libiio_0.16.bb
@@ -1,31 +1,3 @@
-SUMMARY = "Library for interfacing with IIO devices"
-HOMEPAGE = "https://wiki.analog.com/resources/tools-software/linux-software/libiio"
-SECTION = "libs"
-LICENSE = "LGPLv2.1+"
-LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
+SRCREV = "e868971c7fc3a1829abda893075e3fd3d034e08e"
 
-BRANCH = "2018_R2"
-SRCREV = "${AUTOREV}"
-
-PV_append = "+git${SRCPV}"
-
-SRC_URI = "git://github.com/analogdevicesinc/libiio.git;branch=${BRANCH}"
-
-S = "${WORKDIR}/git"
-
-DEPENDS = "flex-native bison-native avahi libaio libusb1 libxml2"
-
-# skip rpath so that, do_package_qa won't complain about redundant
-# rpaths in the shared objects, since they are being installed to
-# default locations
-EXTRA_OECMAKE += "-DCMAKE_SKIP_RPATH=on -DWITH_SYSVINIT=on"
-
-inherit cmake pkgconfig update-rc.d
-
-INITSCRIPT_NAME = "iiod"
-
-# it depends on lsb to run the iiod service
-# we might want to consider in having iiod as a separate
-# package
-RDEPENDS_${PN} = "lsb"
-
+require libiio.inc

--- a/meta-adi-core/recipes-core/libiio/libiio_0.18.bb
+++ b/meta-adi-core/recipes-core/libiio/libiio_0.18.bb
@@ -1,0 +1,3 @@
+SRCREV = "4e22517c60f3c5e691320871956edede15459ae3"
+
+require libiio.inc


### PR DESCRIPTION
Added libiio_0.18 recipe. This involved some re-work in order to avoid
duplication between 0.16 and 0.18 recipes.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>