### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -37,7 +37,8 @@ SRC_URI += " \
 	file://pl-delete-nodes-vc707_fmcdaq2.dtsi \
 	file://pl-delete-nodes-vc707_fmcadc2.dtsi \
 	file://pl-delete-nodes-vc707_fmcomms2-3.dtsi \
-	file://pl-delete-nodes-vc707_fmcjesdadc1.dtsi"
+	file://pl-delete-nodes-vc707_fmcjesdadc1.dtsi \
+	file://pl-delete-nodes-vc707_fmcadc5.dtsi"
 
 # Set this variable with the desired device tree
 # Supported device tree files
@@ -79,6 +80,7 @@ SRC_URI += " \
 #	* vc707_fmcadc2
 #	* vc707_fmcomms2-3
 #	* vc707_fmcjesdadc1
+#	* vc707_fmcadc5
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
 # used for sanity check
@@ -116,7 +118,8 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				vc707_fmcdaq2 \
 				vc707_fmcadc2 \
 				vc707_fmcomms2-3 \
-				vc707_fmcjesdadc1"
+				vc707_fmcjesdadc1 \
+				vc707_fmcadc5"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -7,6 +7,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcadc4.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi \
@@ -48,6 +49,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-fmcdaq2
 #	* zynq-zed-adv7511-fmcmotcon2
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
+#	* zynq-zc706-adv7511
 #	* zynq-zc706-adv7511-adrv9009
 #	* zynq-zc706-adv7511-fmcadc4
 #	* zynq-zc706-adv7511-adrv9371
@@ -89,6 +91,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcdaq2 \
 			zynq-zed-adv7511-fmcmotcon2 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz \
+			zynq-zc706-adv7511 \
 			zynq-zc706-adv7511-adrv9009 \
 			zynq-zc706-adv7511-fmcadc4 \
 			zynq-zc706-adv7511-adrv9371 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -35,7 +35,8 @@ SRC_URI += " \
 	file://pl-delete-nodes-kcu105_fmcomms2-3.dtsi \
 	file://pl-delete-nodes-vc707_fmcdaq2.dtsi \
 	file://pl-delete-nodes-vc707_fmcadc2.dtsi \
-	file://pl-delete-nodes-vc707_fmcomms2-3.dtsi"
+	file://pl-delete-nodes-vc707_fmcomms2-3.dtsi \
+	file://pl-delete-nodes-vc707_fmcjesdadc1.dtsi"
 
 # Set this variable with the desired device tree
 # Supported device tree files
@@ -75,6 +76,7 @@ SRC_URI += " \
 #	* vc707_fmcdaq2
 #	* vc707_fmcadc2
 #	* vc707_fmcomms2-3
+#	* vc707_fmcjesdadc1
 KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 
 # used for sanity check
@@ -110,7 +112,8 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kc705_fmcomms2-3 \
 				vc707_fmcdaq2 \
 				vc707_fmcadc2 \
-				vc707_fmcomms2-3"
+				vc707_fmcomms2-3 \
+				vc707_fmcjesdadc1"
 
 DTS_INCLUDE_PATH_zynq = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts"
 DTS_INCLUDE_PATH_zynqmp = "${STAGING_KERNEL_DIR}/arch/${ARCH}/boot/dts/xilinx"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -17,6 +17,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -54,6 +55,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9361-fmcomms2-3
 #	* zynq-zc706-adv7511-ad9361-fmcomms5
 #	* zynq-zc706-adv7511-fmcdaq3-revC
+#	* zynq-zc706-adv7511-fmcjesdadc1
 #	* zynq-zed-imageon
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #  - For zynqMP platforms:
@@ -91,6 +93,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9361-fmcomms5 \
 			zynq-zc706-adv7511-fmcdaq3-revC \
+			zynq-zc706-adv7511-fmcjesdadc1 \
 			zynq-zed-imageon \
 			zynq-zc702-adv7511-ad9361-fmcomms5"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -30,6 +30,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-kc705_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kc705_ad9467_fmc.dtsi \
 	file://pl-delete-nodes-kc705_fmcomms2-3.dtsi \
+	file://pl-delete-nodes-kc705_fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-kcu105_fmcdaq2.dtsi \
 	file://pl-delete-nodes-kcu105_adrv9371x.dtsi \
 	file://pl-delete-nodes-kcu105_fmcomms2-3.dtsi \
@@ -70,6 +71,7 @@ SRC_URI += " \
 #	* kc705_fmcdaq2
 #	* kc705_ad9467_fmc
 #	* kc705_fmcomms2-3
+#	* kc705_fmcjesdadc1
 #	* kcu105_fmcdaq2
 #	* kcu105_adrv9371x
 #	* kcu105_fmcomms2-3
@@ -110,6 +112,7 @@ KERNEL_DTB_SUPPORTED_microblaze = "kc705_fmcdaq2 \
 				kcu105_fmcomms2-3 \
 				kc705_ad9467_fmc \
 				kc705_fmcomms2-3 \
+				kc705_fmcjesdadc1 \
 				vc707_fmcdaq2 \
 				vc707_fmcadc2 \
 				vc707_fmcomms2-3 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcjesdadc1.dtsi
@@ -1,0 +1,24 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9250_0_core;
+/delete-node/ &axi_ad9250_0_dma;
+/delete-node/ &axi_ad9250_1_core;
+/delete-node/ &axi_ad9250_1_dma;
+/delete-node/ &axi_ad9250_jesd_rx_axi;
+/delete-node/ &axi_ad9250_xcvr;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc5.dtsi
@@ -1,0 +1,27 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9625_0_core;
+/delete-node/ &axi_ad9625_0_jesd_rx_axi;
+/delete-node/ &axi_ad9625_0_xcvr;
+/delete-node/ &axi_ad9625_1_core;
+/delete-node/ &axi_ad9625_1_jesd_rx_axi;
+/delete-node/ &axi_ad9625_1_xcvr;
+/delete-node/ &axi_ad9625_dma;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_fmcadc5_sync;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcjesdadc1.dtsi
@@ -1,0 +1,25 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &sys_mb;
+/delete-node/ &clk_cpu;
+/delete-node/ &clk_bus_0;
+/delete-node/ &axi_ad9250_0_core;
+/delete-node/ &axi_ad9250_0_dma;
+/delete-node/ &axi_ad9250_1_core;
+/delete-node/ &axi_ad9250_1_dma;
+/delete-node/ &axi_ad9250_jesd_rx_axi;
+/delete-node/ &axi_ad9250_xcvr;
+/delete-node/ &axi_ethernet;
+/delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_gpio;
+/delete-node/ &axi_gpio_lcd;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_intc;
+/delete-node/ &axi_linear_flash;
+/delete-node/ &axi_spi;
+/delete-node/ &axi_timer;
+/delete-node/ &axi_uart;
+/delete-node/ &sys_mb_debug;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi
@@ -1,0 +1,19 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9250_0_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9250_0_dma;
+/delete-node/ &axi_ad9250_1_core;
+/delete-node/ &axi_ad9250_1_dma;
+/delete-node/ &axi_ad9250_jesd_rx_axi;
+/delete-node/ &axi_ad9250_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_1;


### PR DESCRIPTION
This PR adds support for:

- fmcjesdadc1_kc705;

- fmcjesdadc1_vc707;

- fmcjesdadc1_zc706;

- fmcadc5_vc707;

- adv7511_zc706.