### PR TITLE
Dev add meta bsp layer

### DIFF
--- a/meta-adi-bsp/COPYING.MIT
+++ b/meta-adi-bsp/COPYING.MIT
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/meta-adi-bsp/README.md
+++ b/meta-adi-bsp/README.md
@@ -1,0 +1,44 @@
+## META-ADI-BSP
+
+This is the Analog Devices yocto layer to make it easy to integrate ADI linux kernel, device trees and other BSP related utilities in your custom yocto machine.
+
+**This layer is compatible with yocto sumo, thud and warrior!**
+
+
+### Including it in your yocto build
+
+To include this layer on your yocto build, you just have to add it to your `bblayers.conf` file as for any other layer.
+
+### ADI kernel
+
+As for now, this layer is not defining any  machine configuration, since all the supported machines are already implemented in another yocto layers. So, to use ADI kernel you should add the following line to your `local.conf` file:
+
+```bash
+PREFERRED_PROVIDER_virtual/kernel = "linux-adi"
+```
+
+or to use ADI master branch:
+
+```bash
+PREFERRED_PROVIDER_virtual/kernel = "linux-adi-dev"
+```
+
+If you are defining your own custom machine, you should add one of the above lines to your machine configuration file. Also, you should append linux-adi recipe to add your machine to the list of `COMPATIBLE_MACHINE`, since linux-adi recipe is setting this variable to the list of machines supported by it. Bellow, is an example of how linux-adi recipe can be extended (with normal yocto procedure with bbappend recipes) to support a custom machine:
+
+```bash
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://defconfig"
+
+COMPATIBLE_MACHINE += "|${MACHINE}"
+```
+
+Note that the above example, assumes that you have a working, out of tree, defconfig file to be used with ADI kernel. If one of the ADI, in tree, defconfig files is enough, the above recipe can be simplified to:
+
+```bash
+COMPATIBLE_MACHINE += "|${MACHINE}"
+KBUILD_DEFCONFIG_${MACHINE} ?= "${adi_defconfig_file}"
+```
+
+You can see the list of supported machines in `recipes-kernel/linux/linux-adi.inc`, and the default defconfig files (for the supported machines) in `recipes-kernel/linux/linux-adi-configs.inc`.
+
+The linux-adi recipe will also compile all the device trees which are supported for the machine being built with yocto.

--- a/meta-adi-bsp/conf/layer.conf
+++ b/meta-adi-bsp/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "adi-bsp"
+BBFILE_PATTERN_adi-bsp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_adi-bsp = "6"
+
+LAYERDEPENDS_adi-bsp = "core"
+LAYERSERIES_COMPAT_adi-bsp = "sumo thud warrior"

--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi-configs.inc
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi-configs.inc
@@ -1,0 +1,7 @@
+# set here all know defconfig files. They should depend
+# on the target machine
+KBUILD_DEFCONFIG_zynq ?= "zynq_xcomm_adv7511_defconfig"
+KBUILD_DEFCONFIG_zynqmp ?= "adi_zynqmp_defconfig"
+KBUILD_DEFCONFIG_microblaze ?= "adi_mb_defconfig"
+
+KCONFIG_MODE ?= "alldefconfig"

--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi-dev.bb
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi-dev.bb
@@ -1,0 +1,119 @@
+LINUX_VERSION = "4.14"
+LINUX_RELEASE = "dev"
+
+KBRANCH = "master"
+
+# Compile all the device tree's for all the plafforms supported
+# by this recipe.
+# Device trees for zc706 platforms
+KERNEL_DEVICETREE_zc706-zynq7 += " \
+			zynq-zc706-adv7511-ad6676-fmc.dtb \
+			zynq-zc706-adv7511-ad9136-fmc-ebz.dtb \
+			zynq-zc706-adv7511-ad9172-fmc-ebz.dtb \
+			zynq-zc706-adv7511-ad9265-fmc-125ebz.dtb \
+			zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5-ext-lo-adf5355.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5-userspace.dtb \
+			zynq-zc706-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zc706-adv7511-ad9434-fmc-500ebz.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc2.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc3.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc7.dtb \
+			zynq-zc706-adv7511-ad9739a-fmc.dtb \
+			zynq-zc706-adv7511-adrv9009.dtb \
+			zynq-zc706-adv7511-adrv9363.dtb \
+			zynq-zc706-adv7511-adrv9371.dtb \
+			zynq-zc706-adv7511-adrv9375.dtb \
+			zynq-zc706-adv7511.dtb \
+			zynq-zc706-adv7511-fmcadc4.dtb \
+			zynq-zc706-adv7511-fmcdaq1.dtb \
+			zynq-zc706-adv7511-fmcdaq2.dtb \
+			zynq-zc706-adv7511-fmcdaq3.dtb \
+			zynq-zc706-adv7511-fmcdaq3-revC.dtb \
+			zynq-zc706-adv7511-fmcjesdadc1.dtb \
+			zynq-zc706-adv7511-fmcomms11.dtb \
+			zynq-zc706-adv7511-fmcomms11-RevA.dtb \
+			zynq-zc706-adv7511-fmcomms1.dtb \
+			zynq-zc706-adv7511-fmcomms6.dtb \
+			zynq-zc706.dtb "
+
+# Device trees for zc702 platforms
+KERNEL_DEVICETREE_zc702-zynq7 += " \
+			zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms5.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms5-userspace.dtb \
+			zynq-zc702-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zc702-adv7511-adrv9363.dtb \
+			zynq-zc702-adv7511.dtb \
+			zynq-zc702-adv7511-fmcomms1.dtb \
+			zynq-zc702.dtb "
+
+# Device trees for zed platforms
+KERNEL_DEVICETREE_zedboard-zynq7 += " \
+			zynq-zed-adf7242.dtb \
+			zynq-zed-adv7511-ad4020.dtb \
+			zynq-zed-adv7511-ad5593r.dtb \
+			zynq-zed-adv7511-ad7768.dtb \
+			zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zed-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zed-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zed-adv7511-ad9467-fmc-250ebz.dtb \
+			zynq-zed-adv7511-adrv9363.dtb \
+			zynq-zed-adv7511-cn0363.dtb \
+			zynq-zed-adv7511-display-rotary-test.dtb \
+			zynq-zed-adv7511.dtb \
+			zynq-zed-adv7511-fmcmotcon2.dtb \
+			zynq-zed-adv7511-fmcomms1.dtb \
+			zynq-zed-adv7511-imageon-loopback.dtb \
+			zynq-zed-adv7511-m2k-revb.dtb \
+			zynq-zed-adv7511-m2k-revc.dtb \
+			zynq-zed-adv7511-pmod-ad1-da1.dtb \
+			zynq-zed.dtb \
+			zynq-zed-imageon.dtb \
+			zynq-zed-seps525.dtb "
+
+# Device trees for zcu102 platforms
+KERNEL_DEVICETREE_zcu102-zynqmp += " \
+			zynqmp-zcu102-rev10-ad9172-fmc-ebz.dtb \
+			zynqmp-zcu102-rev10-ad9172-fmc-ebz-mode4.dtb \
+			zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtb \
+			zynqmp-zcu102-rev10-ad9361-fmcomms5.dtb \
+			zynqmp-zcu102-rev10-ad9361-fmcomms5-ext-lo-adf5355.dtb \
+			zynqmp-zcu102-rev10-ad9364-fmcomms4.dtb \
+			zynqmp-zcu102-rev10-adrv9008-1.dtb \
+			zynqmp-zcu102-rev10-adrv9008-2.dtb \
+			zynqmp-zcu102-rev10-adrv9009.dtb \
+			zynqmp-zcu102-rev10-adrv9371.dtb \
+			zynqmp-zcu102-rev10-adrv9375.dtb \
+			zynqmp-zcu102-rev1.0.dtb \
+			zynqmp-zcu102-rev10-fmcdaq2.dtb \
+			zynqmp-zcu102-rev10-fmcdaq3.dtb \
+			zynqmp-zcu102-revA.dtb \
+			zynqmp-zcu102-revB-ad9361-fmcomms2-3.dtb \
+			zynqmp-zcu102-revB-ad9364-fmcomms4.dtb \
+			zynqmp-zcu102-revB-adrv9363.dtb \
+			zynqmp-zcu102-revB.dtb"
+
+# Device trees for zcu104 platforms
+KERNEL_DEVICETREE_zcu104-zynqmp += " \
+			zynqmp-zcu104-revA.dtb \
+			zynqmp-zcu104-revC.dtb"
+
+# Device trees for zcu106 platforms
+KERNEL_DEVICETREE_zcu106-zynqmp += " \
+			zynqmp-zcu106-revA.dtb"
+
+# Device trees for kc705 platforms
+KERNEL_DEVICETREE_kc705-microblazeel += " \
+			kc705_ad9467_fmc.dtb \
+			kc705.dtb \
+			kc705_fmcdaq2.dtsb \
+			kc705_fmcjesdadc1.dtb \
+			kc705_fmcomms1.dtb \
+			kc705_fmcomms2-3.dtb \
+			kc705_fmcomms4.dtb"
+
+require linux-adi.inc

--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi.inc
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi.inc
@@ -1,0 +1,28 @@
+SECTION = "kernel"
+DESCRIPTION = "Linux kernel for ADI platforms"
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
+
+inherit kernel
+inherit kernel-yocto
+
+# Default to master
+KBRANCH ?= "master"
+# Default to latest revision
+SRCREV ?= "${AUTOREV}"
+
+PV = "${LINUX_VERSION}-${LINUX_RELEASE}+git${SRCPV}"
+
+SRC_URI = "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${KBRANCH}"
+
+S = "${WORKDIR}/git"
+
+# only allow known compatible machines
+COMPATIBLE_MACHINE = "microblaze|zynq|zynqmp"
+KMACHINE ?= "${MACHINE}"
+
+require linux-adi-configs.inc
+
+# add extra tasks (taken from linux-yocto.inc)
+addtask kernel_version_sanity_check after do_kernel_metadata do_kernel_checkout before do_compile
+addtask kernel_configcheck after do_configure before do_compile

--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi_2018-R2.bb
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi_2018-R2.bb
@@ -1,0 +1,112 @@
+LINUX_VERSION = "4.14"
+LINUX_RELEASE = "2018_R2"
+
+KBRANCH = "2018_R2"
+
+# Device trees for zc706 platforms
+KERNEL_DEVICETREE_zc706-zynq7 += " \
+			zynq-zc706-adv7511-ad6676-fmc.dtb \
+			zynq-zc706-adv7511-ad9136-fmc-ebz.dtb \
+			zynq-zc706-adv7511-ad9265-fmc-125ebz.dtb \
+			zynq-zc706-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5-ext-lo-adf5355.dtb \
+			zynq-zc706-adv7511-ad9361-fmcomms5-userspace.dtb \
+			zynq-zc706-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zc706-adv7511-ad9434-fmc-500ebz.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc2.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc3.dtb \
+			zynq-zc706-adv7511-ad9625-fmcadc7.dtb \
+			zynq-zc706-adv7511-ad9739a-fmc.dtb \
+			zynq-zc706-adv7511-adrv9009.dtb \
+			zynq-zc706-adv7511-adrv9363.dtb \
+			zynq-zc706-adv7511-adrv9371.dtb \
+			zynq-zc706-adv7511-adrv9375.dtb \
+			zynq-zc706-adv7511.dtb \
+			zynq-zc706-adv7511-fmcadc4.dtb \
+			zynq-zc706-adv7511-fmcdaq1.dtb \
+			zynq-zc706-adv7511-fmcdaq2.dtb \
+			zynq-zc706-adv7511-fmcdaq3.dtb \
+			zynq-zc706-adv7511-fmcdaq3-revC.dtb \
+			zynq-zc706-adv7511-fmcjesdadc1.dtb \
+			zynq-zc706-adv7511-fmcomms11.dtb \
+			zynq-zc706-adv7511-fmcomms11-RevA.dtb \
+			zynq-zc706-adv7511-fmcomms1.dtb \
+			zynq-zc706-adv7511-fmcomms6.dtb \
+			zynq-zc706.dtb \
+			zynq-zc706-imageon.dtb"
+
+# Device trees for zc702 platforms
+KERNEL_DEVICETREE_zc702-zynq7 += " \
+			zynq-zc702-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms5.dtb \
+			zynq-zc702-adv7511-ad9361-fmcomms5-userspace.dtb \
+			zynq-zc702-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zc702-adv7511-adrv9363.dtb \
+			zynq-zc702-adv7511.dtb \
+			zynq-zc702-adv7511-fmcomms1.dtb \
+			zynq-zc702.dtb"
+
+# Device trees for zed platforms
+KERNEL_DEVICETREE_zedboard-zynq7 += " \
+			zynq-zed-adf7242.dtb \
+			zynq-zed-adv7511-ad4020.dtb \
+			zynq-zed-adv7511-ad5593r.dtb \
+			zynq-zed-adv7511-ad7768.dtb \
+			zynq-zed-adv7511-ad9361-4-fmcomms2-3-4-userspace.dtb \
+			zynq-zed-adv7511-ad9361-fmcomms2-3.dtb \
+			zynq-zed-adv7511-ad9364-fmcomms4.dtb \
+			zynq-zed-adv7511-ad9467-fmc-250ebz.dtb \
+			zynq-zed-adv7511-adrv9363.dtb \
+			zynq-zed-adv7511-cn0363.dtb \
+			zynq-zed-adv7511-display-rotary-test.dtb \
+			zynq-zed-adv7511.dtb \
+			zynq-zed-adv7511-fmcmotcon2.dtb \
+			zynq-zed-adv7511-fmcomms1.dtb \
+			zynq-zed-adv7511-imageon-loopback.dtb \
+			zynq-zed-adv7511-pmod-ad1-da1.dtb \
+			zynq-zed.dtb \
+			zynq-zed-imageon.dtb \
+			zynq-zed-seps525.dtb"
+
+# Device trees for zcu102 platforms
+KERNEL_DEVICETREE_zcu102-zynqmp.conf += " \
+			zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtb \
+			zynqmp-zcu102-rev10-ad9361-fmcomms5.dtb \
+			zynqmp-zcu102-rev10-ad9361-fmcomms5-ext-lo-adf5355.dtb \
+			zynqmp-zcu102-rev10-ad9364-fmcomms4.dtb \
+			zynqmp-zcu102-rev10-adrv9008-1.dtb \
+			zynqmp-zcu102-rev10-adrv9008-2.dtb \
+			zynqmp-zcu102-rev10-adrv9009.dtb \
+			zynqmp-zcu102-rev10-adrv9371.dtb \
+			zynqmp-zcu102-rev10-adrv9375.dtb \
+			zynqmp-zcu102-rev1.0.dtb \
+			zynqmp-zcu102-rev10-fmcdaq2.dtb \
+			zynqmp-zcu102-rev10-fmcdaq3.dtb \
+			zynqmp-zcu102-revA.dtb \
+			zynqmp-zcu102-revB-ad9361-fmcomms2-3.dtb \
+			zynqmp-zcu102-revB-ad9364-fmcomms4.dtb \
+			zynqmp-zcu102-revB-adrv9363.dtb \
+			zynqmp-zcu102-revB.dtb"
+
+# Device trees for zcu104 platforms
+KERNEL_DEVICETREE_zcu104-zynqmp += " \
+			zynqmp-zcu104-revA.dtb \
+			zynqmp-zcu104-revC.dtb"
+
+# Device trees for zcu106 platforms
+KERNEL_DEVICETREE_zcu106-zynqmp += " \
+			zynqmp-zcu106-revA.dtb"
+
+# Device trees for kc705 platforms
+KERNEL_DEVICETREE_kc705-microblazeel += " \
+			kc705_ad9467_fmc.dtb \
+			kc705_fmcdaq2.dtsb \
+			kc705_fmcjesdadc1.dtb \
+			kc705_fmcomms1.dtb \
+			kc705_fmcomms2-3.dtb \
+			kc705_fmcomms4.dtb"
+
+require linux-adi.inc


### PR DESCRIPTION
This PR addresses #12 

This bsp layer is intended to be used with plain yocto and not with petalinux as meta-adi-xilinx. As for now, there's only a recipe for compiling ADI kernel and the available device tree's. ADI kernel is only compiled for supported machines (as for now, zynq, zynqmp and microblaze) which are defined via COMPATIBLE_MACHINE.This can be easily extended by
appending the recipe or directly changing it. Also note, that for building for example for zc706-zynq7 machine, the meta-xilinx-bsp layer has to be added since this layer is not redefining machines which are already defined in another yocto layer's.