### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -22,6 +22,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi \
+	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -69,6 +70,7 @@ SRC_URI += " \
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #	* zynq-zc702-adv7511
 #	* zynq-adrv9361-z7035-bob-cmos
+#	* zynq-adrv9361-z7035-box
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -113,7 +115,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zed-imageon \
 			zynq-zc702-adv7511 \
 			zynq-zc702-adv7511-ad9361-fmcomms5 \
-			zynq-adrv9361-z7035-bob-cmos"
+			zynq-adrv9361-z7035-bob-cmos \
+			zynq-adrv9361-z7035-box"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \
+	file://pl-delete-nodes-zynq-zed-adv7511.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-fmcmotcon2.dtsi \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511.dtsi \
@@ -47,6 +48,7 @@ SRC_URI += " \
 #	* zynq-zed-adv7511-ad9361-fmcomms2-3
 #	* zynq-zc706-adv7511-ad9434-fmc-500ebz
 #	* zynq-zc706-adv7511-fmcdaq2
+#	* zynq-zed-adv7511
 #	* zynq-zed-adv7511-fmcmotcon2
 #	* zynq-zed-adv7511-ad9467-fmc-250ebz
 #	* zynq-zc706-adv7511
@@ -89,6 +91,7 @@ KERNEL_DTB = "zynq-zed-adv7511-ad9361-fmcomms2-3"
 KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9434-fmc-500ebz \
 			zynq-zc706-adv7511-fmcdaq2 \
+			zynq-zed-adv7511 \
 			zynq-zed-adv7511-fmcmotcon2 \
 			zynq-zed-adv7511-ad9467-fmc-250ebz \
 			zynq-zc706-adv7511 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -23,6 +23,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
+	file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -71,6 +72,7 @@ SRC_URI += " \
 #	* zynq-zc702-adv7511
 #	* zynq-adrv9361-z7035-bob-cmos
 #	* zynq-adrv9361-z7035-box
+#	* zynq-adrv9361-z7035-fmc
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -116,7 +118,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc702-adv7511 \
 			zynq-zc702-adv7511-ad9361-fmcomms5 \
 			zynq-adrv9361-z7035-bob-cmos \
-			zynq-adrv9361-z7035-box"
+			zynq-adrv9361-z7035-box \
+			zynq-adrv9361-z7035-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -21,6 +21,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
+	file://pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -67,6 +68,7 @@ SRC_URI += " \
 #	* zynq-zed-imageon
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #	* zynq-zc702-adv7511
+#	* zynq-adrv9361-z7035-bob-cmos
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -110,7 +112,8 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcjesdadc1 \
 			zynq-zed-imageon \
 			zynq-zc702-adv7511 \
-			zynq-zc702-adv7511-ad9361-fmcomms5"
+			zynq-zc702-adv7511-ad9361-fmcomms5 \
+			zynq-adrv9361-z7035-bob-cmos"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
 			zynqmp-zcu102-rev10-adrv9371 \
@@ -189,6 +192,8 @@ do_configure_append() {
 			# zynq has some corner cases that must be taken into account
 			if [ "${KERNEL_DTB}" == "zynq-zc706-adv7511-fmcdaq3-revC" ]; then
 				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-zc706-adv7511-fmcdaq3.dts"
+			elif [ "${KERNEL_DTB}" == "zynq-adrv9361-z7035-bob-cmos" ]; then
+				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-adrv9361-z7035-bob.dts"
 			else
 				dtb_ver_file="${WORKDIR}/system-user.dtsi"
 			fi

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -22,6 +22,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
+	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi \
@@ -65,6 +66,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-fmcjesdadc1
 #	* zynq-zed-imageon
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
+#	* zynq-zc702-adv7511
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
 #	* zynqmp-zcu102-rev10-fmcdaq2
@@ -107,6 +109,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-fmcdaq3-revC \
 			zynq-zc706-adv7511-fmcjesdadc1 \
 			zynq-zed-imageon \
+			zynq-zc702-adv7511 \
 			zynq-zc702-adv7511-ad9361-fmcomms5"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_gpreg;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_pz_xcvrlb;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_iic_main;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi
@@ -1,0 +1,20 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_gpreg;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_pz_xcvrlb;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &phy0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_1;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511.dtsi
@@ -1,0 +1,14 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_iic_fmc;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;


### PR DESCRIPTION
This PR adds support for:

- adv7511_zed;

- adv7511_zc702;

- adrv9361z7035_ccbob_cmos;

- adrv9361z7035_ccbox_lvds;

- adrv9361z7035_ccfmc_lvds.