### PR TITLE
New meta-adi-xilinx supported projects

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -22,6 +22,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi \
+	file://pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
@@ -71,6 +72,7 @@ SRC_URI += " \
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #	* zynq-zc702-adv7511
 #	* zynq-adrv9361-z7035-bob-cmos
+#	* zynq-adrv9361-z7035-bob
 #	* zynq-adrv9361-z7035-box
 #	* zynq-adrv9361-z7035-fmc
 #  - For zynqMP platforms:
@@ -118,6 +120,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc702-adv7511 \
 			zynq-zc702-adv7511-ad9361-fmcomms5 \
 			zynq-adrv9361-z7035-bob-cmos \
+			zynq-adrv9361-z7035-bob \
 			zynq-adrv9361-z7035-box \
 			zynq-adrv9361-z7035-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -27,6 +27,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \
 	file://pl-delete-nodes-zynq-adrv9364-z7020-bob-cmos.dtsi \
+	file://pl-delete-nodes-zynq-adrv9364-z7020-bob.dtsi \
 	file://pl-delete-nodes-zynq-adrv9364-z7020-box.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
@@ -79,6 +80,7 @@ SRC_URI += " \
 #	* zynq-adrv9361-z7035-bob
 #	* zynq-adrv9361-z7035-box
 #	* zynq-adrv9364-z7020-bob-cmos
+#	* zynq-adrv9364-z7020-bob
 #	* zynq-adrv9364-z7020-box
 #	* zynq-adrv9361-z7035-fmc
 #  - For zynqMP platforms:
@@ -130,6 +132,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-adrv9361-z7035-bob \
 			zynq-adrv9361-z7035-box \
 			zynq-adrv9364-z7020-bob-cmos \
+			zynq-adrv9364-z7020-bob \
 			zynq-adrv9364-z7020-box \
 			zynq-adrv9361-z7035-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -27,6 +27,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \
 	file://pl-delete-nodes-zynq-adrv9364-z7020-bob-cmos.dtsi \
+	file://pl-delete-nodes-zynq-adrv9364-z7020-box.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -78,6 +79,7 @@ SRC_URI += " \
 #	* zynq-adrv9361-z7035-bob
 #	* zynq-adrv9361-z7035-box
 #	* zynq-adrv9364-z7020-bob-cmos
+#	* zynq-adrv9364-z7020-box
 #	* zynq-adrv9361-z7035-fmc
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
@@ -128,6 +130,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-adrv9361-z7035-bob \
 			zynq-adrv9361-z7035-box \
 			zynq-adrv9364-z7020-bob-cmos \
+			zynq-adrv9364-z7020-box \
 			zynq-adrv9361-z7035-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -25,6 +25,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-box.dtsi \
 	file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \
+	file://pl-delete-nodes-zynq-adrv9364-z7020-bob-cmos.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi \
 	file://pl-delete-nodes-zynq-zc702-adv7511.dtsi \
 	file://pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi \
@@ -74,6 +75,7 @@ SRC_URI += " \
 #	* zynq-adrv9361-z7035-bob-cmos
 #	* zynq-adrv9361-z7035-bob
 #	* zynq-adrv9361-z7035-box
+#	* zynq-adrv9364-z7020-bob-cmos
 #	* zynq-adrv9361-z7035-fmc
 #  - For zynqMP platforms:
 #	* zynqmp-zcu102-rev10-adrv9009
@@ -122,6 +124,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-adrv9361-z7035-bob-cmos \
 			zynq-adrv9361-z7035-bob \
 			zynq-adrv9361-z7035-box \
+			zynq-adrv9364-z7020-bob-cmos \
 			zynq-adrv9361-z7035-fmc"
 KERNEL_DTB_SUPPORTED_zynqmp = "zynqmp-zcu102-rev10-adrv9009 \
 			zynqmp-zcu102-rev10-fmcdaq2 \
@@ -203,6 +206,8 @@ do_configure_append() {
 				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-zc706-adv7511-fmcdaq3.dts"
 			elif [ "${KERNEL_DTB}" == "zynq-adrv9361-z7035-bob-cmos" ]; then
 				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-adrv9361-z7035-bob.dts"
+			elif [ "${KERNEL_DTB}" == "zynq-adrv9364-z7020-bob-cmos" ]; then
+				dtb_ver_file="${DTS_INCLUDE_PATH}/zynq-adrv9364-z7020-bob.dts"
 			else
 				dtb_ver_file="${WORKDIR}/system-user.dtsi"
 			fi

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -18,6 +18,7 @@ SRC_URI += " \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9265-fmc-125ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi \
+	file://pl-delete-nodes-zynq-zc706-adv7511-fmcomms11.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi \
 	file://pl-delete-nodes-zynq-zed-imageon.dtsi \
@@ -69,6 +70,7 @@ SRC_URI += " \
 #	* zynq-zc706-adv7511-ad9361-fmcomms5
 #	* zynq-zc706-adv7511-fmcdaq3-revC
 #	* zynq-zc706-adv7511-fmcjesdadc1
+#	* zynq-zc706-adv7511-fmcomms11
 #	* zynq-zed-imageon
 #	* zynq-zc702-adv7511-ad9361-fmcomms5
 #	* zynq-zc702-adv7511
@@ -118,6 +120,7 @@ KERNEL_DTB_SUPPORTED_zynq = "zynq-zed-adv7511-ad9361-fmcomms2-3 \
 			zynq-zc706-adv7511-ad9361-fmcomms5 \
 			zynq-zc706-adv7511-fmcdaq3-revC \
 			zynq-zc706-adv7511-fmcjesdadc1 \
+			zynq-zc706-adv7511-fmcomms11 \
 			zynq-zed-imageon \
 			zynq-zc702-adv7511 \
 			zynq-zc702-adv7511-ad9361-fmcomms5 \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_gpreg;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_pz_xcvrlb;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-bob-cmos.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-bob-cmos.dtsi
@@ -1,0 +1,11 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_gpreg;
+/delete-node/ &axi_iic_main;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-bob.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-bob.dtsi
@@ -1,0 +1,11 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_gpreg;
+/delete-node/ &axi_iic_main;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-box.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9364-z7020-box.dtsi
@@ -1,0 +1,12 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9361;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9361_adc_dma;
+/delete-node/ &axi_ad9361_dac_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_iic_main;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcomms11.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcomms11.dtsi
@@ -1,0 +1,21 @@
+/*Delete nodes from pl.dtsi which are redefined in ADI dts*/
+/ {
+	/delete-node/ aliases;
+};
+
+/delete-node/ &axi_ad9162_core_tpl_core;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_ad9162_dma;
+/delete-node/ &axi_ad9162_jesd_tx_axi;
+/delete-node/ &axi_ad9162_xcvr;
+/delete-node/ &axi_ad9625_core_tpl_core;
+/delete-node/ &axi_ad9625_dma;
+/delete-node/ &axi_ad9625_jesd_rx_axi;
+/delete-node/ &axi_ad9625_xcvr;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &misc_clk_2;


### PR DESCRIPTION
This PR adds support for:

- adrv9364z7020_ccbob_lvds;

- adrv9364z7020_ccbox_lvds;

- fmcomms11_zc706;

- adrv9364z7020_ccbob_cmos;

- adrv9361z7035_ccbob_lvds.