### PR TITLE
meta-adi-xilinx: Delete axi_sysid_0 core

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_ad9467_fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_ad9467_fmc.dtsi
@@ -18,3 +18,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcdaq2.dtsi
@@ -2,4 +2,5 @@
 
 /delete-node/ &axi_gpio_lcd;
 /delete-node/ &axi_linear_flash;
+/delete-node/ &axi_sysid_0;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcjesdadc1.dtsi
@@ -22,3 +22,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kc705_fmcomms2-3.dtsi
@@ -19,3 +19,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
@@ -30,4 +30,5 @@
 /delete-node/ &rx_ad9371_tpl_core_tpl_core;
 /delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcdaq2.dtsi
@@ -2,3 +2,4 @@
 
 /delete-node/ &axi_ddr_cntrl;
 /delete-node/ &axi_ethernet_dma;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_fmcomms2-3.dtsi
@@ -19,3 +19,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc2.dtsi
@@ -21,3 +21,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcadc5.dtsi
@@ -25,3 +25,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcjesdadc1.dtsi
@@ -23,3 +23,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-vc707_fmcomms2-3.dtsi
@@ -20,3 +20,4 @@
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
 /delete-node/ &sys_mb_debug;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511-ad9361-fmcomms5.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc702-adv7511.dtsi
@@ -10,3 +10,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_1;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad6676-fmc.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms2-3.dtsi
@@ -14,3 +14,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9361-fmcomms5.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi
@@ -13,3 +13,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9625-fmcadc2.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-ad9739a-fmc.dtsi
@@ -13,3 +13,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
@@ -27,3 +27,4 @@
 /delete-node/ &rx_adrv9009_tpl_core_tpl_core;
 /delete-node/ &rx_os_adrv9009_tpl_core_tpl_core;
 /delete-node/ &tx_adrv9009_tpl_core_tpl_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
@@ -27,3 +27,4 @@
 /delete-node/ &rx_ad9371_tpl_core_tpl_core;
 /delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
 /delete-node/ &tx_ad9371_tpl_core_tpl_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi
@@ -19,3 +19,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
@@ -19,3 +19,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcjesdadc1.dtsi
@@ -17,3 +17,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511.dtsi
@@ -10,3 +10,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
 /delete-node/ &misc_clk_1;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9361-fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9361-fmcomms2-3.dtsi
@@ -16,4 +16,5 @@
 /delete-node/ &misc_clk_0;
 /delete-node/ &misc_clk_1;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-ad9467-fmc-250ebz.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_iic_fmc;
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511.dtsi
@@ -12,3 +12,4 @@
 /delete-node/ &axi_iic_fmc;
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-imageon.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-imageon.dtsi
@@ -17,3 +17,4 @@
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_rx_core;
 /delete-node/ &axi_spdif_tx_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms2-3.dtsi
@@ -9,3 +9,4 @@
 /delete-node/ &axi_ad9361_dac_dma;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-ad9361-fmcomms5.dtsi
@@ -10,3 +10,4 @@
 /delete-node/ &axi_ad9361_dac_dma;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
@@ -24,4 +24,5 @@
 /delete-node/ &misc_clk_0;
 /delete-node/ &misc_clk_1;
 /delete-node/ &misc_clk_2;
+/delete-node/ &axi_sysid_0;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
@@ -22,3 +22,4 @@
 /delete-node/ &rx_ad9371_tpl_core_tpl_core;
 /delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
 /delete-node/ &tx_ad9371_tpl_core_tpl_core;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq2.dtsi
@@ -14,3 +14,4 @@
 /delete-node/ &axi_ad9680_xcvr;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
+/delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
@@ -15,3 +15,4 @@
 /delete-node/ &axi_ad9680_xcvr;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
+/delete-node/ &axi_sysid_0;


### PR DESCRIPTION
The axi_sysid_0 ip core was added in a number of hdl projects, so that,
the respective devicetree files need to be updated in order to avoid
errors with duplicate labels.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>