### PR TITLE
meta-adi-xilinx: kernel: Allow config fragments

### DIFF
--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -2,7 +2,7 @@ DESCRIPTION = "ADI kernel"
 BRANCH = "master"
 # always use latest source revision
 SRCREV = "${AUTOREV}"
-SRC_URI = "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${BRANCH}"
+SRC_URI += "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${BRANCH}"
 KBRANCH = "${BRANCH}"
 PV = "4.14"
 # override kernel config file


### PR DESCRIPTION
Since the kernel recipe was just overwriting `SRC_URI`, any config
fragment created with `petalinux-config -c kernel` was not being copied
to the build WORKDIR. Hence, it was not possible to add/remove kernel
configurations on top of the selected kernel defconfig file.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>