### PR TITLE
meta-adi-xilinx: Fix zcu102-rev10-adrv9009 project

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
@@ -23,6 +23,5 @@
 /delete-node/ &tx_adrv9009_tpl_core_tpl_core;
 /delete-node/ &misc_clk_0;
 /delete-node/ &misc_clk_1;
-/delete-node/ &misc_clk_2;
 /delete-node/ &axi_sysid_0;
 


### PR DESCRIPTION
The hdl project and the meta layer were out of sync. misc_clk_2 is no
longer used so that we don't have to remove it. This would actually lead
to a build fail of the devicetree.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>