### PR TITLE
treewide: use 2018_R2 branch for all projects

### DIFF
--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi-dev.bb
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi-dev.bb
@@ -1,7 +1,7 @@
 LINUX_VERSION = "4.14"
 LINUX_RELEASE = "dev"
 
-KBRANCH = "master"
+KBRANCH = "2018_R2"
 
 # Compile all the device tree's for all the plafforms supported
 # by this recipe.

--- a/meta-adi-bsp/recipes-kernel/linux/linux-adi.inc
+++ b/meta-adi-bsp/recipes-kernel/linux/linux-adi.inc
@@ -6,8 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 inherit kernel
 inherit kernel-yocto
 
-# Default to master
-KBRANCH ?= "master"
+KBRANCH ?= "2018_R2"
 # Default to latest revision
 SRCREV ?= "${AUTOREV}"
 

--- a/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
+++ b/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
@@ -2,7 +2,7 @@ SUMMARY = "Library to manage multi-chip sync on FMCOMMS5 platforms with multiple
 SECTION = "libs"
 LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=40d2542b8c43a3ec2b7f5da31a697b88"
-BRANCH = "master"
+BRANCH = "2018_R2"
 
 # just pick the last revision on master
 SRCREV = "${AUTOREV}"

--- a/meta-adi-core/recipes-core/libiio/libiio.inc
+++ b/meta-adi-core/recipes-core/libiio/libiio.inc
@@ -4,7 +4,7 @@ SECTION = "libs"
 LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
 
-BRANCH ?= "master"
+BRANCH ?= "2018_R2"
 
 SRC_URI = "git://github.com/analogdevicesinc/libiio.git;branch=${BRANCH}"
 S = "${WORKDIR}/git"

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -1,5 +1,5 @@
 DESCRIPTION = "ADI kernel"
-BRANCH = "master"
+BRANCH = "2018_R2"
 # always use latest source revision
 SRCREV = "${AUTOREV}"
 SRC_URI += "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${BRANCH}"


### PR DESCRIPTION
Otherwise it pulls master and it fails.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>