### PR TITLE
Add support for 2018_R2

### DIFF
--- a/meta-adi-core/recipes-core/libiio/libiio_0.16.bb
+++ b/meta-adi-core/recipes-core/libiio/libiio_0.16.bb
@@ -1,3 +1,3 @@
-SRCREV = "e868971c7fc3a1829abda893075e3fd3d034e08e"
+SRCREV = "69a9dfcc0321b0234d2fa62f9f8d6bc939865324"
 
 require libiio.inc

--- a/meta-adi-core/recipes-core/libiio/libiio_0.18.bb
+++ b/meta-adi-core/recipes-core/libiio/libiio_0.18.bb
@@ -1,3 +1,3 @@
-SRCREV = "4e22517c60f3c5e691320871956edede15459ae3"
+SRCREV = "c5e0ff9afc951c5469f1ff0049f39c32be7f602f"
 
 require libiio.inc

--- a/meta-adi-xilinx/README.md
+++ b/meta-adi-xilinx/README.md
@@ -13,14 +13,17 @@ Xilinx based platforms use Petalinx SDK in order to customize, build and deploy 
 * [Petalinux User guide](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug1144-petalinux-tools-reference-guide.pdf)
 * [Petalinux Wiki](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842250/PetaLinux)
 
-**This layer was tested against Petalinux-v2018.3**.
+**This layer supports:**
+
+*  **Petalinux-v2018.2;**
+*  **hdl_2018_r2 (see [hdl](https://github.com/analogdevicesinc/hdl/releases/tag/2018_r2))**.
 
 To build a petalinux project using Analog Devices yocto layer, run:
 
 ```bash
 source  <path-to-installed-PetaLinux>/settings.sh
 petalinux-create -t project --template <PLATFORM> --name <PROJECT_NAME>, where <PLATFORM> is:
-	* zynqMP (for UltraScale + MPSoC) 
+	* zynqMP (for UltraScale + MPSoC)
 	* zynq (for Zynq)
 	* microblaze (for MicroBlaze)
 git clone https://github.com/analogdevicesinc/meta-adi.git
@@ -35,7 +38,7 @@ petalinux-build
 
 >**IMPORTANT: Since this layer depends on meta-adi-core (because of userspace tools), it has to be included after meta-adi-core, otherwise `petalinux-config` will fail.**
 
-To build a BOOT.bin for [Zynq](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842549/Zynq-7000+SoC) and [ZynqMP](https://www.xilinx.com/products/silicon-devices/soc/zynq-ultrascale-mpsoc.html) platforms run `petalinux-package --boot --fsbl --fpga --u-boot`.  The output file will be placed in `path-to-petalinux-project>/images/linux`. Finally, copy  BOOT.bin and image.ub (FIT image including kernel, device tree and iniramfs) to the boot partition of a SD card.
+To build a BOOT.bin for [Zynq](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842549/Zynq-7000+SoC) and [ZynqMP](https://www.xilinx.com/products/silicon-devices/soc/zynq-ultrascale-mpsoc.html) platforms run `petalinux-package --boot --fsbl <FSBL_ELF> --fpga <BITSTREAM> --u-boot`.  The output file will be placed in `path-to-petalinux-project>/images/linux`. Finally, copy  BOOT.bin and image.ub (FIT image including kernel, device tree and iniramfs) to the boot partition of a SD card.
 
 For [Microblaze](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842560/MicroBlaze) platforms the Xilinx System Debugger is used to run the linux kernel directly from memory. Run the following commands:
 
@@ -54,11 +57,11 @@ con
 
 > Notes:
 >
-1. To build the desired hdf file refer to [Building HDL](https://wiki.analog.com/resources/fpga/docs/build).
-2. To run the produced image.elf (**for microblaze**) make sure that the Xilinx Vivado SDK is installed.
-3. For an overview of `xsdb` refer to [Xilinx System Debugger Overview](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2014_3/SDK_Doc/concepts/sdk_c_xsd_over.htm)
-4. Refer to  [Petalinux User guide](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug1144-petalinux-tools-reference-guide.pdf) for building a MCS boot file for Microblaze
-> 
+>1. To build the desired hdf file refer to [Building HDL](https://wiki.analog.com/resources/fpga/docs/build).
+>2. To run the produced image.elf (**for microblaze**) make sure that the Xilinx Vivado SDK is installed.
+>3. For an overview of `xsdb` refer to [Xilinx System Debugger Overview](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2014_3/SDK_Doc/concepts/sdk_c_xsd_over.htm)
+>4. Refer to  [Petalinux User guide](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2018_3/ug1144-petalinux-tools-reference-guide.pdf) for building a MCS boot file for Microblaze
+
 
 For **Zynq** and **ZynqMP**, one might want to use a complete root filesystem instead of initramfs. To disable initramfs on petalinux:
 
@@ -80,5 +83,5 @@ EXTRA_USERS_PARAMS = "  \
 To extend ADI devicetrees, the normal Petalinux method should be used. Hence, the `system-user.dtsi` file should be used. This file is located under `path-to-project/project-spec/meta-user/recipes-bsp/device-tree/files/`. There is also a `device-tree.bbappend` which automatically selects this file for the build. With this mind, one can either:
 
  1. Directly change this file with the new devicetree nodes;
- 2. Create a new file and add a `#include` or `/include/`directive in `system-user.dtsi`. In these case, changes to the `device-tree.bbappend` recipe are also needed. 
- 
+ 2. Create a new file and add a `#include` or `/include/`directive in `system-user.dtsi`. In these case, changes to the `device-tree.bbappend` recipe are also needed.
+

--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -1,7 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 SRC_URI += " \
-	file://0001-fix-the-clock-frequency-generation.patch \
 	file://pl-delete-nodes-zynq-zed-adv7511-ad9361-fmcomms2-3.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-ad9434-fmc-500ebz.dtsi \
 	file://pl-delete-nodes-zynq-zc706-adv7511-fmcdaq2.dtsi \

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-adi.inc
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-adi.inc
@@ -1,10 +1,12 @@
+require recipes-kernel/linux/linux-xlnx.inc
+
 DESCRIPTION = "ADI kernel"
-BRANCH = "2018_R2"
-# always use latest source revision
-SRCREV = "${AUTOREV}"
-SRC_URI += "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${BRANCH}"
-KBRANCH = "${BRANCH}"
-PV = "4.14"
+# Default to latest revision
+SRCREV ?= "${AUTOREV}"
+PV = "${LINUX_VERSION}-${ADI_VERSION}+git${SRCPV}"
+
+SRC_URI = "git://github.com/analogdevicesinc/linux.git;protocol=https;branch=${KBRANCH}"
+
 # override kernel config file
 KBUILD_DEFCONFIG_zynq = "zynq_xcomm_adv7511_defconfig"
 KBUILD_DEFCONFIG_zynqmp = "adi_zynqmp_defconfig"
@@ -16,4 +18,3 @@ KBUILD_DEFCONFIG_microblaze = "adi_mb_defconfig"
 do_configure_prepend_microblaze() {
 	sed -i 's,CONFIG_INITRAMFS_SOURCE=.*,,' ${B}/.config
 }
-

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_adi-2018_R2.bb
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_adi-2018_R2.bb
@@ -1,0 +1,5 @@
+LINUX_VERSION = "4.14"
+ADI_VERSION = "adi_2018"
+KBRANCH = "2018_R2"
+
+require linux-adi.inc


### PR DESCRIPTION
This PR adds support for petalinux 2018_R2 and hdl_2018_R2. The kernel recipe got some refactoring that will be also added to the other branches.