### PR TITLE
[2019_R1] Offline support

### DIFF
--- a/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
+++ b/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
@@ -5,8 +5,8 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://license.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 BRANCH = "2019_R1"
-# just pick the last revision on master
-SRCREV = "${AUTOREV}"
+# If we are in an offline build we cannot use AUTOREV since it would require internet!
+SRCREV = "${@ "9c360ea67d153fefe32713aa1bfca98d7acd81f9" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/fru_tools.git;protocol=https;branch=${BRANCH}"
 PV_append = "+git${SRCPV}"
 

--- a/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
+++ b/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
@@ -4,7 +4,7 @@ SECTION = "console/utils"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://license.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
-BRANCH = "2018_R2"
+BRANCH = "2019_R1"
 # just pick the last revision on master
 SRCREV = "${AUTOREV}"
 SRC_URI = "git://github.com/analogdevicesinc/fru_tools.git;protocol=https;branch=${BRANCH}"

--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -6,8 +6,8 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 # some warning would be printed...
 NO_GENERIC_LICENSE[ADI-BSD] = "LICENSE.txt"
 
-# just pick the last revision on master
-SRCREV = "${AUTOREV}"
+# If we are in an offline build we cannot use AUTOREV since it would require internet!
+SRCREV = "${@ "45a0eb36c480f11bc0799991a6663d5ff8fb3936" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git"
 
 S = "${WORKDIR}/git"

--- a/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
+++ b/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
@@ -4,7 +4,8 @@ LICENSE = "LGPLv2.1+"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=40d2542b8c43a3ec2b7f5da31a697b88"
 BRANCH = "2019_R1"
 
-SRCREV = "${AUTOREV}"
+# If we are in an offline build we cannot use AUTOREV since it would require internet!
+SRCREV = "${@ "11293f8fa201ab1ceae80f351b71d53ac4be8198" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 PV_append = "+git${SRCPV}"
 
 SRC_URI = "git://github.com/analogdevicesinc/libad9361-iio.git;protocol=https;branch=${BRANCH}"

--- a/meta-adi-xilinx/README.md
+++ b/meta-adi-xilinx/README.md
@@ -84,3 +84,6 @@ To extend ADI devicetrees, the normal Petalinux method should be used. Hence, th
  1. Directly change this file with the new devicetree nodes;
  2. Create a new file and add a `#include` or `/include/`directive in `system-user.dtsi`. In these case, changes to the `device-tree.bbappend` recipe are also needed.
 
+### Offline Build
+
+To build petalinux without internet access, run `petalinux-config` and select `BB_NO_NETWORK`. Check [Xilinx Yocto Builds without an Internet Connection](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/60129817/Xilinx+Yocto+Builds+without+an+Internet+Connection) for more information.

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_adi-2019_R1.bb
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_adi-2019_R1.bb
@@ -2,4 +2,6 @@ LINUX_VERSION = "4.14"
 ADI_VERSION = "adi_2019"
 KBRANCH = "2019_R1"
 
+# needed for offline build
+SRCREV = "${@ "abfd28fb5f9d88b5888809c7c80c7f404186b23b" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 require linux-adi.inc


### PR DESCRIPTION
This PR adds support for buiding petalinux without internet access...
In addition, it fixes the branch being checked out on fru-tools.