### PR TITLE
meta-adi-core: jesd-status: Set branch to checkout

### DIFF
--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -6,9 +6,10 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 # some warning would be printed...
 NO_GENERIC_LICENSE[ADI-BSD] = "LICENSE.txt"
 
+BRANCH = "master"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
 SRCREV = "${@ "63766a54193a107dab6ee289ae3e63177621c4a7" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
-SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git"
+SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Explicitly set master as the branch to checkout.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>