### PR TITLE
meta-adi-core: jesd-status: Fix branch to checkout

### DIFF
--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -6,9 +6,10 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 # some warning would be printed...
 NO_GENERIC_LICENSE[ADI-BSD] = "LICENSE.txt"
 
+branch = "2019_R1"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
 SRCREV = "${@ "45a0eb36c480f11bc0799991a6663d5ff8fb3936" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
-SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git"
+SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Set 2019_R1 as the branch to checkout. Master was being used by
default...

Signed-off-by: Nuno Sá <nuno.sa@analog.com>