### PR TITLE
meta-adi-xilinx: jesd_status: Fix wrong name

### DIFF
--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 # some warning would be printed...
 NO_GENERIC_LICENSE[ADI-BSD] = "LICENSE.txt"
 
-branch = "2019_R1"
+BRANCH = "2019_R1"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
 SRCREV = "${@ "45a0eb36c480f11bc0799991a6663d5ff8fb3936" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;branch=${BRANCH}"


### PR DESCRIPTION
The fetch function fails because BRANCH was being defined with a
different name.

Fixes: fa89041 ("meta-adi-core: jesd-status: Fix branch to checkout")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>