### PR TITLE
Update pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi
@@ -10,3 +10,4 @@
 /delete-node/ &axi_gpreg;
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_pz_xcvrlb;
+/delete-node/ &axi_sysid_0;


### PR DESCRIPTION
 pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi is missing axi_sysid_0 node delete. it will without its inclusion build will fail with a duplication error message.