### PR TITLE
meta-adi-core: Use https to fetch git repo

### DIFF
--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -9,7 +9,7 @@ NO_GENERIC_LICENSE[ADI-BSD] = "LICENSE.txt"
 BRANCH = "master"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
 SRCREV = "${@ "63766a54193a107dab6ee289ae3e63177621c4a7" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
-SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;protocol=https;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"
 

--- a/meta-adi-core/recipes-core/libiio/libiio.inc
+++ b/meta-adi-core/recipes-core/libiio/libiio.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING.txt;md5=7c13b3376cea0ce68d2d2da0a1b3a72c"
 
 BRANCH ?= "master"
 
-SRC_URI = "git://github.com/analogdevicesinc/libiio.git;branch=${BRANCH}"
+SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https;branch=${BRANCH}"
 S = "${WORKDIR}/git"
 
 DEPENDS = "flex-native bison-native avahi libaio libusb1 libxml2"


### PR DESCRIPTION
This patch makes libiio and jesd to use https to fetch the git repos.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>