### PR TITLE
meta-adi-xilinx: devicetree: Fix projects build

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-kcu105_adrv9371x.dtsi
@@ -23,8 +23,9 @@
 /delete-node/ &axi_spi;
 /delete-node/ &axi_timer;
 /delete-node/ &axi_uart;
-/delete-node/ &rx_ad9371_tpl_core_tpl_core;
-/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_ad9371_tpl_core_adc_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_adc_tpl_core;
 /delete-node/ &sys_mb_debug;
 /delete-node/ &axi_sysid_0;
+/delete-node/ &tx_ad9371_tpl_core_dac_tpl_core;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9009.dtsi
@@ -19,7 +19,7 @@
 /delete-node/ &axi_hdmi_dma;
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
-/delete-node/ &rx_adrv9009_tpl_core_tpl_core;
-/delete-node/ &rx_os_adrv9009_tpl_core_tpl_core;
-/delete-node/ &tx_adrv9009_tpl_core_tpl_core;
+/delete-node/ &rx_adrv9009_tpl_core_adc_tpl_core;
+/delete-node/ &rx_os_adrv9009_tpl_core_adc_tpl_core;
+/delete-node/ &tx_adrv9009_tpl_core_dac_tpl_core;
 /delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-adrv9371.dtsi
@@ -19,7 +19,7 @@
 /delete-node/ &axi_hdmi_dma;
 /delete-node/ &axi_iic_main;
 /delete-node/ &axi_spdif_tx_core;
-/delete-node/ &rx_ad9371_tpl_core_tpl_core;
-/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
-/delete-node/ &tx_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_ad9371_tpl_core_adc_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_adc_tpl_core;
+/delete-node/ &tx_ad9371_tpl_core_dac_tpl_core;
 /delete-node/ &axi_sysid_0;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcomms11.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcomms11.dtsi
@@ -1,10 +1,10 @@
 /*Delete nodes from pl.dtsi which are redefined in ADI dts*/
-/delete-node/ &axi_ad9162_core_tpl_core;
+/delete-node/ &axi_ad9162_core_dac_tpl_core;
 /delete-node/ &misc_clk_0;
 /delete-node/ &axi_ad9162_dma;
 /delete-node/ &axi_ad9162_jesd_tx_axi;
 /delete-node/ &axi_ad9162_xcvr;
-/delete-node/ &axi_ad9625_core_tpl_core;
+/delete-node/ &axi_ad9625_core_adc_tpl_core;
 /delete-node/ &axi_ad9625_dma;
 /delete-node/ &axi_ad9625_jesd_rx_axi;
 /delete-node/ &axi_ad9625_xcvr;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9009.dtsi
@@ -14,9 +14,9 @@
 /delete-node/ &axi_adrv9009_tx_xcvr;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
-/delete-node/ &rx_adrv9009_tpl_core_tpl_core;
-/delete-node/ &rx_os_adrv9009_tpl_core_tpl_core;
-/delete-node/ &tx_adrv9009_tpl_core_tpl_core;
+/delete-node/ &rx_adrv9009_tpl_core_adc_tpl_core;
+/delete-node/ &rx_os_adrv9009_tpl_core_adc_tpl_core;
+/delete-node/ &tx_adrv9009_tpl_core_dac_tpl_core;
 /delete-node/ &misc_clk_0;
 /delete-node/ &axi_sysid_0;
 

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-adrv9371.dtsi
@@ -14,7 +14,7 @@
 /delete-node/ &axi_ad9371_tx_xcvr;
 /delete-node/ &psu_ctrl_ipi;
 /delete-node/ &psu_message_buffers;
-/delete-node/ &rx_ad9371_tpl_core_tpl_core;
-/delete-node/ &rx_os_ad9371_tpl_core_tpl_core;
-/delete-node/ &tx_ad9371_tpl_core_tpl_core;
+/delete-node/ &rx_ad9371_tpl_core_adc_tpl_core;
+/delete-node/ &rx_os_ad9371_tpl_core_adc_tpl_core;
+/delete-node/ &tx_ad9371_tpl_core_dac_tpl_core;
 /delete-node/ &axi_sysid_0;


### PR DESCRIPTION
Some projects fail to build due to some renaming in the hdl projects.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>