### PR TITLE
meta-adi-xilinx: devicetree: Fix projects build

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zc706-adv7511-fmcdaq3-revC.dtsi
@@ -1,10 +1,10 @@
 /*Delete nodes from pl.dtsi which are redefined in ADI dts*/
-/delete-node/ &axi_ad9152_core;
+/delete-node/ &axi_ad9152_tpl_core_dac_tpl_core;
 /delete-node/ &misc_clk_0;
 /delete-node/ &axi_ad9152_dma;
 /delete-node/ &axi_ad9152_jesd_tx_axi;
 /delete-node/ &axi_ad9152_xcvr;
-/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_tpl_core_adc_tpl_core;
 /delete-node/ &axi_ad9680_dma;
 /delete-node/ &axi_ad9680_jesd_rx_axi;
 /delete-node/ &axi_ad9680_xcvr;

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynqmp-zcu102-rev10-fmcdaq3.dtsi
@@ -1,11 +1,11 @@
 /*Delete nodes from pl.dtsi which are redefined in ADI dts*/
-/delete-node/ &axi_ad9152_core;
+/delete-node/ &axi_ad9152_tpl_core_dac_tpl_core;
 /delete-node/ &misc_clk_0;
 /delete-node/ &axi_ad9152_dma;
 /delete-node/ &misc_clk_1;
 /delete-node/ &axi_ad9152_jesd_tx_axi;
 /delete-node/ &axi_ad9152_xcvr;
-/delete-node/ &axi_ad9680_core;
+/delete-node/ &axi_ad9680_tpl_core_adc_tpl_core;
 /delete-node/ &axi_ad9680_dma;
 /delete-node/ &axi_ad9680_jesd_rx_axi;
 /delete-node/ &axi_ad9680_xcvr;


### PR DESCRIPTION
Some projects fail to build due to some renaming in the hdl projects as
detected by CI builds.

Signed-off-by: Nuno Sá <nuno.sa@analog.com>