### PR TITLE
adrv9009 zu11eg fan control 2019_R2

### DIFF
--- a/meta-adi-xilinx/conf/layer.conf
+++ b/meta-adi-xilinx/conf/layer.conf
@@ -19,13 +19,6 @@ LAYERDEPENDS_adi-xilinx += "openembedded-layer"
 # for userspace tools
 LAYERDEPENDS_adi-xilinx += "adi-core"
 
-# The .bbappend and .bb files are included if the respective layer
-# collection is available.
-BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bbappend' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-BBFILES += "${@' '.join('${LAYERDIR}/dynamic-layers/%s/recipes*/*/*.bb' % layer \
-               for layer in BBFILE_COLLECTIONS.split())}"
-
 BBFILES_DYNAMIC += " \
     meta-plnx-generated:${LAYERDIR}/dynamic-layers/meta-plnx-generated/*/*/*.bb \
     meta-plnx-generated:${LAYERDIR}/dynamic-layers/meta-plnx-generated/*/*/*.bbappend \

--- a/meta-adi-xilinx/dynamic-layers/meta-plnx-generated/recipes-core/images/petalinux-user-image.bbappend
+++ b/meta-adi-xilinx/dynamic-layers/meta-plnx-generated/recipes-core/images/petalinux-user-image.bbappend
@@ -3,7 +3,8 @@ IMAGE_INSTALL_append = " libiio  \
 			 libiio-iiod \
 			 fru-tools \
 			 libad9361-iio \
-			 jesd-status"
+			 jesd-status \
+			 adrv9009-zu11eg-fan-control"
 
 # The petalinux default root password is root. To change it, one
 # has to run petalinux-config -c rootfs and change the passoword. This lines below

--- a/meta-adi-xilinx/recipes-support/adrv9009-zu11eg-fan-control-daemon/adrv9009-zu11eg-fan-control_dev.bb
+++ b/meta-adi-xilinx/recipes-support/adrv9009-zu11eg-fan-control-daemon/adrv9009-zu11eg-fan-control_dev.bb
@@ -1,0 +1,20 @@
+SUMMARY = "System daemon for controlling the fan speed on the ADRV9009-ZU11EG System On Module."
+SECTION = "base"
+LICENSE = "ADI-BSD"
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
+BRANCH = "2019_R2"
+
+SRCREV = "${@ "0503352702e5944fca303af9e23b25216d59c00c" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRC_URI = "git://github.com/analogdevicesinc/adrv9009-zu11eg-fan-control-daemon.git;protocol=https;branch=${BRANCH}"
+PV_append = "+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+inherit update-rc.d cmake
+
+DEPENDS = "libiio"
+
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '-DWITH_SYSVINIT=on', '', d)}"
+
+INITSCRIPT_NAME = "fancontrold"
+RDEPENDS_${PN} += "lsb"


### PR DESCRIPTION
Same as #88 but with the new recipe applied to 2019_R2 so that it checks out the 2019_R2 branch