### PR TITLE
meta-adi-xilinx: libiio: fix build for microblaze

### DIFF
--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -6,6 +6,9 @@ PV = "0.21+git${SRCPV}"
 SRC_URI += "file://syvinitscript.patch"
 
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '-DWITH_SYSVINIT=on', '', d)}"
+# This is enabled by default if network_backend is enabled. But if zeroconf is not present, we cannot
+# have DHAVE_DNS_SD=ON
+EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'zeroconf', '', '-DHAVE_DNS_SD=off', d)}"
 
 inherit update-rc.d
 
@@ -14,4 +17,3 @@ INITSCRIPT_NAME = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'iiod', '
 PACKAGECONFIG ?= "USB_BACKEND NETWORK_BACKEND PYTHON_BINDINGS SERIAL_BACKEND"
 
 PACKAGECONFIG[SERIAL_BACKEND] = "-DWITH_SERIAL_BACKEND=ON,-DWITH_SERIAL_BACKEND=off,libserialport libxml2"
-


### PR DESCRIPTION
This fix is still related with the changes introduced by [1]. If
'HAVE_DNS_SD' is ON, we need to have the correspondent avahi dependencies
set... However, for microblaze builds, zeroconf is not part of the
petalinux 'DISTRO_FEATURES'. Hence, we disable 'DHAVE_DNS_SD' if zeroconf
is not present.

[1]: https://github.com/analogdevicesinc/libiio/pull/680
Signed-off-by: Nuno Sá <nuno.sa@analog.com>