### PR TITLE
Import the Zed ADRV9002 dtsi renames onto 2019_R2 to match with ADI Linux branch 2019_R2 

### DIFF
--- a/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/device-tree.bbappend
@@ -23,8 +23,8 @@ SRC_URI_append_zynq = " \
 		file://pl-delete-nodes-zynq-zc706-adv7511-ad9172-fmc-ebz.dtsi \
 		file://pl-delete-nodes-zynq-zc706-adv7511-adrv9375-jesd204-fsm.dtsi \
 		file://pl-delete-nodes-zynq-zed-imageon.dtsi \
-		file://pl-delete-nodes-zynq-zed-adrv9002.dtsi \
-		file://pl-delete-nodes-zynq-zed-adrv9002-rx2tx2.dtsi \
+		file://pl-delete-nodes-zynq-zed-adv7511-adrv9002.dtsi \
+		file://pl-delete-nodes-zynq-zed-adv7511-adrv9002-rx2tx2.dtsi \
 		file://pl-delete-nodes-zynq-adrv9361-z7035-bob-cmos.dtsi \
 		file://pl-delete-nodes-zynq-adrv9361-z7035-bob.dtsi \
 		file://pl-delete-nodes-zynq-adrv9361-z7035-fmc.dtsi \

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adrv9002-rx2tx2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adrv9002-rx2tx2.dtsi
@@ -1,1 +1,0 @@
-/include/ "pl-delete-nodes-zynq-zed-adrv9002.dtsi"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-adrv9002-rx2tx2.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-adrv9002-rx2tx2.dtsi
@@ -1,0 +1,1 @@
+/include/ "pl-delete-nodes-zynq-zed-adv7511-adrv9002.dtsi"

--- a/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-adrv9002.dtsi
+++ b/meta-adi-xilinx/recipes-bsp/device-tree/files/pl-delete-nodes-zynq-zed-adv7511-adrv9002.dtsi
@@ -1,0 +1,16 @@
+/delete-node/ &axi_adrv9001;
+/delete-node/ &axi_adrv9001_rx1_dma;
+/delete-node/ &misc_clk_0;
+/delete-node/ &axi_adrv9001_rx2_dma;
+/delete-node/ &axi_adrv9001_tx1_dma;
+/delete-node/ &axi_adrv9001_tx2_dma;
+/delete-node/ &axi_hdmi_clkgen;
+/delete-node/ &axi_hdmi_core;
+/delete-node/ &misc_clk_1;
+/delete-node/ &axi_hdmi_dma;
+/delete-node/ &axi_i2s_adi;
+/delete-node/ &misc_clk_2;
+/delete-node/ &axi_iic_fmc;
+/delete-node/ &axi_iic_main;
+/delete-node/ &axi_spdif_tx_core;
+/delete-node/ &axi_sysid_0;


### PR DESCRIPTION
Renamed ADRV9002 Zed pl-delete-nodes dtsi files to match changes made to ADI Linux Kernel 2019_R2 branch.