### PR TITLE
meta-adi-xilinx: libiio: fix branch selection

### DIFF
--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -1,9 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 BRANCH ?= "master"
 SRCREV = "${@ "56f7db743651e02a838aab7bf224978da8661b22" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
-SRC_URI_append = ";branch=${BRANCH}"
+SRC_URI_append = ";branch=${BRANCH} file://syvinitscript.patch"
 PV = "0.21+git${SRCPV}"
-SRC_URI += "file://syvinitscript.patch"
 
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '-DWITH_SYSVINIT=on', '', d)}"
 # This is enabled by default if network_backend is enabled. But if zeroconf is not present, we cannot


### PR DESCRIPTION
Add the sysvinit patch in the same SRC_URI append line. Otherwise, the
'+=' operator has precedence over '_append' which means that the ';branch='
key will not be applied to the 'git://' URI and hence, we cannot specify
the branch to checkout. It will always use master no matter what is
given in BRANCH'.

Fixes: cd042513d600 ("meta-adi-xilinx: libiio: remove lsb runtime dependency")
Signed-off-by: Nuno Sá <nuno.sa@analog.com>