### PR TITLE
petalinux 2021.2 support

### DIFF
--- a/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
+++ b/meta-adi-core/recipes-core/fru-tools/fru-tools_0.8.1.5.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://license.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 BRANCH = "master"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "5ee5bf5ab59abdcc350df79696758ea5ff9f33c7" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "72951d8e76d4e3ea047ecbbebe52a980c1909c56" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/fru_tools.git;protocol=https;branch=${BRANCH}"
 PV_append = "+git${SRCPV}"
 

--- a/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-core/recipes-core/jesd-status/jesd-status_dev.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 
 BRANCH = "master"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "ba6364123d6c820d3490aa2c91e41c8cb859ce30" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "693567d31f4377c392928ed121202f691c41e39a" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;protocol=https;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"

--- a/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
+++ b/meta-adi-core/recipes-core/libad9361-iio/libad9361-iio_0.2.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=40d2542b8c43a3ec2b7f5da31a697b88"
 BRANCH = "master"
 
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "fe0babd3f36bfad26da393339665f809e04da239" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "43643ab0ef8a3fbdb6c7595f42842f534a291664" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 PV_append = "+git${SRCPV}"
 
 SRC_URI = "git://github.com/analogdevicesinc/libad9361-iio.git;protocol=https;branch=${BRANCH}"

--- a/meta-adi-xilinx/README.md
+++ b/meta-adi-xilinx/README.md
@@ -73,12 +73,12 @@ To add Analog devices tools (eg: libiio) the [meta-adi-core](https://github.com/
 
 Xilinx based platforms use Petalinx SDK in order to customize, build and deploy Embedded Linux on their platforms. Petalinux is a set of tools which work on top of yocto making it easy to add extra custom layers. For more information on Petalinux and on how to install the SDK refer to the following links:
 
-* [Petalinux User guide](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2021_1/ug1144-petalinux-tools-reference-guide.pdf)
+* [Petalinux User guide](https://www.xilinx.com/support/documentation/sw_manuals/xilinx2021_2/ug1144-petalinux-tools-reference-guide.pdf)
 * [Petalinux Wiki](https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/18842250/PetaLinux)
 
 **This layer supports:**
 
-* **Petalinux-v2021.1;**
+* **Petalinux-v2021.2;**
 * **hdl master branch (see [hdl](https://github.com/analogdevicesinc/hdl)).**
 
 To build a petalinux project using Analog Devices yocto layer, run:
@@ -124,13 +124,6 @@ con
 ```
 
 After running `con`, on your Serial terminal, stop u-boot at the command line and run `bootm 0x85000000`. Your kernel should now start to boot...
-
-### A note on ZynqMP
-
-There are some identified issues in petalinux on ultrascale platforms:
-
-1. When using initrd/initramfs as root filesystem, petalinux-initramfs-image will be automatically selected as ramdisk and the boot will fail (if there's no valid ext4 partition on the sdcard) since it is a tiny image that does not contain everything needed to successfully finish the boot process. Workarounds can be found [here](https://support.xilinx.com/s/article/76842?language=en_US);
-2. On the bootlog, the following can be seen: "**[Firmware Bug]: Kernel image misaligned at boot, please fix your bootloader!**". Explanations and solutions [here](https://support.xilinx.com/s/article/76712?language=en_US).
 
 > Notes:
 >

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -5,7 +5,7 @@ ADI_VERSION = "adi_master"
 PV = "${LINUX_VERSION}-${ADI_VERSION}+git${SRCPV}"
 KBRANCH = "master"
 # needed for offline build
-SRCREV = "${@ "564bb35721991e0a65efd72aca0d40e6cb5f0ce7" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "21a88cb29186148047515e1ec844ef237386bcf9" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 KERNELURI = "git://github.com/analogdevicesinc/linux.git;protocol=https"
 
 # override kernel config file

--- a/meta-adi-xilinx/recipes-support/adrv9009-zu11eg-fan-control-daemon/adrv9009-zu11eg-fan-control_dev.bb
+++ b/meta-adi-xilinx/recipes-support/adrv9009-zu11eg-fan-control-daemon/adrv9009-zu11eg-fan-control_dev.bb
@@ -4,7 +4,7 @@ LICENSE = "ADI-BSD"
 LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 BRANCH = "master"
 
-SRCREV = "${@ "0503352702e5944fca303af9e23b25216d59c00c" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "e00aed02214146e61c9087a57b2918b48efeabde" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "\
 	git://github.com/analogdevicesinc/adrv9009-zu11eg-fan-control-daemon.git;protocol=https;branch=${BRANCH} \
 	file://syvinitscript.patch \

--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -2,7 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 BRANCH ?= "master"
 SRCREV = "${@ "92d6a35f3d8d721cda7d6fe664b435311dd368b4" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI_append = ";branch=${BRANCH} file://syvinitscript.patch"
-PV = "0.23+git${SRCPV}"
+PV = "0.24+git${SRCPV}"
 
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '-DWITH_SYSVINIT=on', '', d)}"
 # This is enabled by default if network_backend is enabled. But if zeroconf is not present, we cannot

--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 BRANCH ?= "master"
-SRCREV = "${@ "92d6a35f3d8d721cda7d6fe664b435311dd368b4" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "4a869116f0bad8d669319611c0ebb4596a33e2a3" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI_append = ";branch=${BRANCH} file://syvinitscript.patch"
 PV = "0.24+git${SRCPV}"
 


### PR DESCRIPTION
Support petalinux 2021.2 version. The support was pretty straight and boils down to readme and git sha updates (also libiio was updated so that the package name reflects the right version)