### PR TITLE
layer.conf: Add support for Dunfell branch

### DIFF
--- a/meta-adi-core/conf/layer.conf
+++ b/meta-adi-core/conf/layer.conf
@@ -9,7 +9,7 @@ BBFILE_COLLECTIONS += "adi-core"
 BBFILE_PATTERN_adi-core = "^${LAYERDIR}/"
 BBFILE_PRIORITY_adi-core = "6"
 
-LAYERSERIES_COMPAT_adi-core = "rocko sumo thud warrior zeus gatesgarth"
+LAYERSERIES_COMPAT_adi-core = "rocko sumo thud warrior zeus dunfell gatesgarth"
 
 LAYERDEPENDS_adi-core = "core"
 


### PR DESCRIPTION
 * Tested by building libiio for use with gnuradio.

Signed-off-by: Philip Balister <philip@balister.org>