### PR TITLE
meta-adi-xilinx: recipes-support: libiio: move to libbio-v0 branch

### DIFF
--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -1,5 +1,5 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
-BRANCH ?= "master"
+BRANCH ?= "libiio-v0"
 SRCREV = "${@ "c4498c27761d04d4ac631ec59c1613bfed079da5" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 # Just overwrite SRC_URI as we would need to delete the python bindings patch since it does not apply
 # (already fixed in 0.24) and we do not want to hardcode ';branch=master' so that we would also have to
@@ -7,7 +7,7 @@ SRCREV = "${@ "c4498c27761d04d4ac631ec59c1613bfed079da5" if bb.utils.to_boolean(
 SRC_URI = "git://github.com/analogdevicesinc/libiio.git;protocol=https;branch=${BRANCH} \
            file://syvinitscript.patch \
 "
-PV = "0.24+git${SRCPV}"
+PV = "0.25+git${SRCPV}"
 
 EXTRA_OECMAKE += "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '-DWITH_SYSVINIT=on', '', d)}"
 # This is enabled by default if network_backend is enabled. But if zeroconf is not present, we cannot


### PR DESCRIPTION
Libiio renamed the master branch to main. More importantly, it moved to libiio v1.0 which is not backward compatible (at least for now) with libiio v0. Hence, all the projects that 'DEPEND' on libiio will fail to compile in meta-adi. Since it might take some time for those projects to be converted, let's move to the v0 branch and update the package 'PV' accordingly.

Fixes #128 