### PR TITLE
meta-adi-xilinx: petalinux-image-minimal: really remove avahi-daemon

### DIFF
--- a/meta-adi-xilinx/dynamic-layers/meta-petalinux/recipes-core/images/petalinux-image-minimal.bbappend
+++ b/meta-adi-xilinx/dynamic-layers/meta-petalinux/recipes-core/images/petalinux-image-minimal.bbappend
@@ -8,7 +8,7 @@ IMAGE_INSTALL:append = " libiio  \
 			 jesd-status \
 			 adrv9009-zu11eg-fan-control"
 
-IMAGE_INSTALL:microblaze:remove = "avahi-daemon"
+IMAGE_INSTALL:remove:microblaze = "avahi-daemon"
 
 # Mimic what petalinux is doing in petalinux.conf. The big difference is that the user is
 # called analog instead of petalinux. Also, we just set 'analog' as the root password to


### PR DESCRIPTION
On Microblaze, zeroconf is not enabled so that we can remove avahi-daemon from the image. However, we were trying to do the remove action after the microblaze override and so, the package was still included in the image. Fix it by placing the override in it's place after the ':remove' action.