### PR TITLE
meta-adi-xilinx: recipes-kernel: linux: fix kernel version

### DIFF
--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -1,11 +1,11 @@
 DESCRIPTION = "ADI kernel"
-LINUX_VERSION = "5.15"
+LINUX_VERSION = "5.15.36"
 ADI_VERSION = "adi_master"
 
 PV = "${LINUX_VERSION}-${ADI_VERSION}+git${SRCPV}"
 KBRANCH = "2022_R2"
 # needed for offline build
-SRCREV = "${@ "77fc5a3f95023e1f966c827f35fef3f6cfdf66d4" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "cd7e20c430dc19df7c32610e9d5b494d8f313e07" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 KERNELURI = "git://github.com/analogdevicesinc/linux.git;protocol=https"
 
 # override kernel config file


### PR DESCRIPTION
With the changes introduced in [1], the kernel version moved to 5.15.36. Properly set the version in here.

While at it, change the default git sha (should match the next tag) to checkout in case of an offline build.

[1]: https://github.com/analogdevicesinc/linux/pull/2405
Signed-off-by: Nuno Sa <nuno.sa@analog.com>