### PR TITLE
meta-adi-xilinx: linux: rename 'master' > 'main'

### DIFF
--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -1,9 +1,9 @@
 DESCRIPTION = "ADI kernel"
 LINUX_VERSION = "6.1"
-ADI_VERSION = "adi-master"
+ADI_VERSION = "adi-main"
 
 PV = "${LINUX_VERSION}-${ADI_VERSION}+git${SRCPV}"
-KBRANCH = "master"
+KBRANCH = "main"
 # needed for offline build
 SRCREV = "${@ "dc4d9bb93a52833fb3950389e2b9a5be58767eb3" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 KERNELURI = "git://github.com/analogdevicesinc/linux.git;protocol=https"


### PR DESCRIPTION
We now use main in linux and master was removed. So update it in here.