### PR TITLE
gitignore: don't ignore patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .vscode/*
 *.diff
-*.patch
 *.swp


### PR DESCRIPTION
	This is necessary for maintaining the two syvinitscript.patch files located in: 
		1. meta-adi-xilinx/recipes-support/adrv9009-zu11eg-fan-control-daemon/files/ 
		2. meta-adi-xilinx/recipes-support/libiio/files/ 