### PR TITLE
ci: petalinux-build: fix getting hdl artifacts

### DIFF
--- a/ci/petalinux-build.sh
+++ b/ci/petalinux-build.sh
@@ -29,7 +29,7 @@ get_hdl_artifact() {
 
 	if [[ ${l} == ${folders} ]]; then
 		echo "Could not find HDL artifact for: \"${project}\""
-		exit 1
+		return 1
 	fi
 
 	echo "Get hdl artifacts from: ${base_path}/${export_branch}/hdl_output/${hdl}/${project}"


### PR DESCRIPTION
Some artifacts are still not available in the 'main' export so that we try to use the legacy 'master'. However, get_hdl_artifacts was doing an 'exit 1' in case no artifact was found. Hence, we don't have a shot in trying the 'master' path.