### PR TITLE
meta-adi-xilinx: libiio: fix offline build

### DIFF
--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 BRANCH ?= "2023_R2"
-SRCREV = "${@ "54eb23f4b5c6093916f208772627f7b68f495559" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "76524f4fd6a62e56a5fe309c36d327ff6d1c7248" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 # Just overwrite SRC_URI as we would need to delete the python bindings patch since it does not apply
 # (already fixed in 0.24) and we do not want to hardcode ';branch=master' so that we would also have to
 # remove that leaving the variable empty anyways.


### PR DESCRIPTION
The offline git hash for libiio was wrong and did not existed. Fix it...

Should fix #162 