### PR TITLE
Add pyADI-IIO Recipe

### DIFF
--- a/meta-adi-xilinx/dynamic-layers/meta-petalinux/recipes-core/images/petalinux-image-minimal.bbappend
+++ b/meta-adi-xilinx/dynamic-layers/meta-petalinux/recipes-core/images/petalinux-image-minimal.bbappend
@@ -2,6 +2,7 @@ IMAGE_INSTALL:append = " libiio  \
 			 libiio-tests \
 			 libiio-iiod \
 			 libiio-python3 \
+			 pyadi-iio \
 			 avahi-daemon \
 			 fru-tools \
 			 libad9361-iio \

--- a/meta-adi-xilinx/recipes-support/pyadi-iio/pyadi-iio_0.0.19.bb
+++ b/meta-adi-xilinx/recipes-support/pyadi-iio/pyadi-iio_0.0.19.bb
@@ -1,0 +1,16 @@
+
+SUMMARY = "Analog Devices python interfaces for hardware with Industrial I/O drivers"
+LICENSE = "ADI-BSD"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=d02cc2377387c6fa1ffe41e81f191cf0"
+
+BRANCH ?= "main"
+SRCREV = "${@ "bcadbe85ffce80739c01c283674ebfee1bbb90ab" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRC_URI = "git://github.com/analogdevicesinc/pyadi-iio.git;protocol=https;branch=${BRANCH}"
+PV:append = "+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN} = "python3-numpy (>=1.20) \
+				  libiio-python3 (>=0.23.1)"
+
+inherit python_setuptools_build_meta


### PR DESCRIPTION
Adds a recipe for pyADI-IIO to include the Python package in meta-adi based projects.

This was requested by a customer who wished to run pyADI-IIO based Python projects directly on their FPGA hardware. It seemed like a useful addition to include this as part of the meta-adi layer.

