### PR TITLE
Add Petalinux 2025.1 support

### DIFF
--- a/Dockerfile.petalinux
+++ b/Dockerfile.petalinux
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN dpkg --add-architecture i386
 RUN apt-get update
@@ -15,9 +15,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y iproute2 gawk python3 buil
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     locale-gen
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
 # set bash as default shell
 RUN echo "dash dash/sh boolean false" | debconf-set-selections

--- a/ci/petalinux-build.sh
+++ b/ci/petalinux-build.sh
@@ -46,7 +46,7 @@ project=$1
 template=$2
 dts=$3
 obsolete=${4:-no}
-PETALINUX="/opt/petalinux/2024.2"
+PETALINUX="/opt/petalinux/2025.1"
 
 # remove any possible leftover
 rm -rf ${project}/

--- a/meta-adi-xilinx/README.md
+++ b/meta-adi-xilinx/README.md
@@ -77,7 +77,7 @@ Xilinx based platforms use Petalinx SDK in order to customize, build and deploy 
 
 **This layer supports:**
 
-* **Petalinux-v2024.2;**
+* **Petalinux-v2025.1;**
 * **hdl main branch (see [hdl](https://github.com/analogdevicesinc/hdl)).**
 
 To build a petalinux project using Analog Devices yocto layer, run:

--- a/meta-adi-xilinx/conf/layer.conf
+++ b/meta-adi-xilinx/conf/layer.conf
@@ -9,17 +9,13 @@ BBFILE_COLLECTIONS += "adi-xilinx"
 BBFILE_PATTERN_adi-xilinx = "^${LAYERDIR}/"
 BBFILE_PRIORITY_adi-xilinx = "8"
 
-# the one used in petalinux 2023.1
+# the one used in petalinux 2025.1
 LAYERSERIES_COMPAT_adi-xilinx = "scarthgap"
 
 LAYERDEPENDS_adi-xilinx = "core"
 LAYERDEPENDS_adi-xilinx += "xilinx"
 LAYERDEPENDS_adi-xilinx += "xilinx-tools"
 LAYERDEPENDS_adi-xilinx += "openembedded-layer"
-
-# xilinx is on 6.6.x. However, we'll only get stable fixes when master is stabilized and branch out to a
-# new release. Hence, overwrite the preferred version.
-PREFERRED_VERSION_linux-xlnx = "6.6-adi-v2024.2%"
 
 BBFILES_DYNAMIC += " \
     petalinux:${LAYERDIR}/dynamic-layers/meta-petalinux/*/*/*.bb \

--- a/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
+++ b/meta-adi-xilinx/recipes-kernel/linux/linux-xlnx_%.bbappend
@@ -1,11 +1,14 @@
 DESCRIPTION = "ADI kernel"
-LINUX_VERSION = "6.6"
-LINUX_VERSION_EXTENSION = "adi-v2024.2"
+LINUX_VERSION_EXTENSION = "adi-v2025.1"
 
+# Note that xilinx is on 6.12.x. but we are still on 6.12 so that will mismatch on the package version.
+# We let it mismatch so we do not mess with PREFERRED_VERSION_linux-xlnx set by xilinx layer in a way that
+# the wrong recipe would be picked or the build would complain about no recipe suiting the preferred version.
+# Also since the major version is the same, there's no issue with the yocto kernel version sanity check.
 PV = "${LINUX_VERSION}-${LINUX_VERSION_EXTENSION}+git${SRCPV}"
 KBRANCH = "main"
 # needed for offline build
-SRCREV = "${@ "c8daf49830b2d19b155756d151f4c881a001a67e" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "ec1bbe510ba6764423efea7738f0feca8d0b4fb1" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 KERNELURI = "git://github.com/analogdevicesinc/linux.git;protocol=https"
 
 # override kernel config file

--- a/meta-adi-xilinx/recipes-support/fru-tools/fru-tools_0.8.1.5.bb
+++ b/meta-adi-xilinx/recipes-support/fru-tools/fru-tools_0.8.1.5.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://license.txt;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 BRANCH = "main"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "4a18979382d59dd956bc11a6606d460e3f8937ca" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "e98eae11db567c8c8b8076998a68ac8467e52646" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/fru_tools.git;protocol=https;branch=${BRANCH}"
 PV:append = "+git${SRCPV}"
 

--- a/meta-adi-xilinx/recipes-support/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-xilinx/recipes-support/jesd-status/jesd-status_dev.bb
@@ -10,21 +10,8 @@ SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;protocol=http
 
 S = "${WORKDIR}/git"
 
-DEPENDS = "ncurses"
+inherit cmake pkgconfig
 
-# so that the compiled artifact respects the OpenEmbedded ldflags
-# fixes the "No GNU_HASH in the elf binary" package_qa error
-TARGET_CC_ARCH += "${LDFLAGS}"
-# overwrite do_compile since we only want to build jesd_status
-do_compile() {
-	oe_runmake jesd_status
-}
+EXTRA_OECMAKE = "-DUSE_JESD_EYE_SCAN=OFF -DUSE_LIBIIO=ON"
 
-bindest = "/usr/local/bin"
-
-FILES:${PN} = "${bindest}/jesd_status"
-
-do_install() {
-	install -d ${D}/${bindest}
-	install -m 755 ${B}/jesd_status ${D}/${bindest}/jesd_status
-}
+DEPENDS = "ncurses libiio"

--- a/meta-adi-xilinx/recipes-support/jesd-status/jesd-status_dev.bb
+++ b/meta-adi-xilinx/recipes-support/jesd-status/jesd-status_dev.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=38c01601d5c4b84986a8f48ece946aa1"
 
 BRANCH = "main"
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "90cad36a2c09e0fbea9763aca4ae0f72f1677bbc" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "960dbda7402c2fcc854dc830372eecb7b469ed67" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/jesd-eye-scan-gtk.git;protocol=https;branch=${BRANCH}"
 
 S = "${WORKDIR}/git"

--- a/meta-adi-xilinx/recipes-support/libad9361-iio/libad9361-iio_0.2.bb
+++ b/meta-adi-xilinx/recipes-support/libad9361-iio/libad9361-iio_0.2.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=40d2542b8c43a3ec2b7f5da31a697b88"
 BRANCH = "main"
 
 # If we are in an offline build we cannot use AUTOREV since it would require internet!
-SRCREV = "${@ "2d81a541d55ad9f2299df3f1a94dfb787d9ee234" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "2264074505ad4911155c815104292c6fbf98f62c" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 PV:append = "+git${SRCPV}"
 
 SRC_URI = "git://github.com/analogdevicesinc/libad9361-iio.git;protocol=https;branch=${BRANCH}"

--- a/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
+++ b/meta-adi-xilinx/recipes-support/libiio/libiio_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 BRANCH ?= "libiio-v0"
-SRCREV = "${@ "1ae8815858d7ca07da2cb7db76ec3fbb1a84588a" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "ba74e6c53007925ff714ed28a258b5aebf6a3ad4" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 # Just overwrite SRC_URI as we would need to delete the python bindings patch since it does not apply
 # (already fixed in 0.24) and we do not want to hardcode ';branch=master' so that we would also have to
 # remove that leaving the variable empty anyways.
@@ -16,7 +16,7 @@ EXTRA_OECMAKE += " \
 	-DBISON_TARGET_ARG_COMPILE_FLAGS='--no-lines' \
 "
 
-inherit update-rc.d pkgconfig
+inherit update-rc.d
 
 INITSCRIPT_NAME = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', 'iiod', '', d)}"
 

--- a/meta-adi-xilinx/recipes-support/pyadi-iio/pyadi-iio_0.0.19.bb
+++ b/meta-adi-xilinx/recipes-support/pyadi-iio/pyadi-iio_0.0.19.bb
@@ -4,7 +4,7 @@ LICENSE = "ADI-BSD"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d02cc2377387c6fa1ffe41e81f191cf0"
 
 BRANCH ?= "main"
-SRCREV = "${@ "bcadbe85ffce80739c01c283674ebfee1bbb90ab" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
+SRCREV = "${@ "6b33acdfdb9910e89d85243fd584c136142587a6" if bb.utils.to_boolean(d.getVar('BB_NO_NETWORK')) else d.getVar('AUTOREV')}"
 SRC_URI = "git://github.com/analogdevicesinc/pyadi-iio.git;protocol=https;branch=${BRANCH}"
 PV:append = "+git${SRCPV}"
 


### PR DESCRIPTION
The first commit fixes jesd_status since the upstream project was modified to use cmake and added support for libiio. The rest is typical changes for a new petalinux version.